### PR TITLE
✨ feat(settings): add app settings storage and API

### DIFF
--- a/cliff.toml
+++ b/cliff.toml
@@ -1,0 +1,39 @@
+[changelog]
+header = "# Changelog\n\n"
+body = """
+{% if version %}\
+## {{ version }} — {{ timestamp | date(format="%Y-%m-%d") }}
+{% else %}\
+## Unreleased
+{% endif %}\
+{% for group, commits in commits | group_by(attribute="group") %}
+### {{ group }}
+{% for commit in commits %}
+- {{ commit.message | upper_first }} ([`{{ commit.id | truncate(length=7, end="") }}`](https://github.com/Bertrand2808/animus/commit/{{ commit.id }}))\
+{% endfor %}
+{% endfor %}\n
+"""
+trim = true
+footer = ""
+
+[git]
+conventional_commits = true
+filter_unconventional = false
+# Strip leading emoji before parsing conventional commit
+commit_preprocessors = [
+  { pattern = '^[^\w\s(]+\s+', replace = "" },
+]
+commit_parsers = [
+  { message = "^feat", group = "Features" },
+  { message = "^fix", group = "Bug Fixes" },
+  { message = "^refactor", group = "Refactor" },
+  { message = "^perf", group = "Performance" },
+  { message = "^test", group = "Tests" },
+  { message = "^docs", group = "Documentation" },
+  { message = "^chore", group = "Chores" },
+  { message = "^build", group = "Build" },
+  { message = "^ci", group = "CI" },
+]
+filter_commits = false
+tag_pattern = "v[0-9].*"
+sort_commits = "newest"

--- a/crates/animus-core/src/lib.rs
+++ b/crates/animus-core/src/lib.rs
@@ -1,7 +1,9 @@
 pub mod character_card;
 pub mod content_rating;
 pub mod persona;
+pub mod settings;
 
 pub use character_card::{CharacterCardV2, CharacterCardV2Data};
 pub use content_rating::ContentRating;
 pub use persona::{CardImportError, Persona};
+pub use settings::AppSettings;

--- a/crates/animus-core/src/settings.rs
+++ b/crates/animus-core/src/settings.rs
@@ -1,0 +1,8 @@
+/// Global application settings persisted in the local database.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct AppSettings {
+    /// Display name for the local user.
+    pub user_name: String,
+    /// Default Ollama model to use when no persona-level model is set.
+    pub default_model: String,
+}

--- a/crates/animus-db/migrations/004_create_app_settings.sql
+++ b/crates/animus-db/migrations/004_create_app_settings.sql
@@ -1,0 +1,5 @@
+CREATE TABLE IF NOT EXISTS app_settings (
+    id            INTEGER PRIMARY KEY CHECK (id = 1),
+    user_name     TEXT NOT NULL DEFAULT 'User',
+    default_model TEXT NOT NULL DEFAULT 'gemma4'
+);

--- a/crates/animus-db/src/lib.rs
+++ b/crates/animus-db/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod conversation_repo;
 pub mod message_repo;
 pub mod persona_repo;
+pub mod settings_repo;
 pub mod summary_repo;
 
 pub use animus_core::content_rating::ContentRating;
@@ -10,3 +11,4 @@ pub use animus_core::persona::Summary;
 pub use conversation_repo::ConversationRepo;
 pub use message_repo::MessageRepo;
 pub use persona_repo::RepoError;
+pub use settings_repo::SettingsRepo;

--- a/crates/animus-db/src/settings_repo.rs
+++ b/crates/animus-db/src/settings_repo.rs
@@ -1,0 +1,112 @@
+use animus_core::AppSettings;
+use sqlx::SqlitePool;
+
+#[derive(Clone)]
+pub struct SettingsRepo {
+    pool: SqlitePool,
+}
+
+impl SettingsRepo {
+    pub fn new(pool: SqlitePool) -> Self {
+        Self { pool }
+    }
+
+    /// Insert the default row only when none exists yet.
+    /// Called once at startup to seed `default_model` from the env.
+    pub async fn init_defaults(&self, default_model: &str) -> Result<(), sqlx::Error> {
+        let rows = sqlx::query!(
+            "INSERT OR IGNORE INTO app_settings (id, user_name, default_model) VALUES (1, 'User', ?)",
+            default_model
+        )
+        .execute(&self.pool)
+        .await?;
+
+        if rows.rows_affected() > 0 {
+            tracing::info!(
+                target: "settings",
+                default_model = %default_model,
+                "settings initialized with defaults"
+            );
+        }
+        Ok(())
+    }
+
+    /// Fetch the singleton settings row.
+    pub async fn get(&self) -> Result<AppSettings, sqlx::Error> {
+        let row = sqlx::query!(
+            r#"SELECT user_name AS "user_name!", default_model AS "default_model!" FROM app_settings WHERE id = 1"#
+        )
+        .fetch_one(&self.pool)
+        .await?;
+
+        tracing::debug!(target: "settings", user_name = %row.user_name, "settings fetched");
+
+        Ok(AppSettings {
+            user_name: row.user_name,
+            default_model: row.default_model,
+        })
+    }
+
+    /// Overwrite the singleton settings row entirely.
+    pub async fn upsert(&self, settings: &AppSettings) -> Result<(), sqlx::Error> {
+        sqlx::query!(
+            "INSERT OR REPLACE INTO app_settings (id, user_name, default_model) VALUES (1, ?, ?)",
+            settings.user_name,
+            settings.default_model,
+        )
+        .execute(&self.pool)
+        .await?;
+
+        tracing::debug!(
+            target: "settings",
+            user_name = %settings.user_name,
+            default_model = %settings.default_model,
+            "settings updated"
+        );
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use sqlx::SqlitePool;
+
+    pub static MIGRATOR: sqlx::migrate::Migrator =
+        sqlx::migrate!("../../crates/animus-db/migrations");
+
+    #[sqlx::test(migrator = "MIGRATOR")]
+    async fn init_defaults_creates_row(pool: SqlitePool) {
+        let repo = SettingsRepo::new(pool);
+        repo.init_defaults("llama3").await.unwrap();
+        let s = repo.get().await.unwrap();
+        assert_eq!(s.user_name, "User");
+        assert_eq!(s.default_model, "llama3");
+    }
+
+    #[sqlx::test(migrator = "MIGRATOR")]
+    async fn init_defaults_is_idempotent(pool: SqlitePool) {
+        let repo = SettingsRepo::new(pool);
+        repo.init_defaults("llama3").await.unwrap();
+        repo.init_defaults("other-model").await.unwrap();
+        let s = repo.get().await.unwrap();
+        assert_eq!(s.default_model, "llama3", "second call must not overwrite");
+    }
+
+    #[sqlx::test(migrator = "MIGRATOR")]
+    async fn upsert_updates_settings(pool: SqlitePool) {
+        let repo = SettingsRepo::new(pool);
+        repo.init_defaults("gemma4").await.unwrap();
+
+        repo.upsert(&AppSettings {
+            user_name: "Bertrand".to_owned(),
+            default_model: "mistral".to_owned(),
+        })
+        .await
+        .unwrap();
+
+        let s = repo.get().await.unwrap();
+        assert_eq!(s.user_name, "Bertrand");
+        assert_eq!(s.default_model, "mistral");
+    }
+}

--- a/crates/animus-llm/src/ollama.rs
+++ b/crates/animus-llm/src/ollama.rs
@@ -117,7 +117,7 @@ impl OllamaClient {
                 .json(&request_body)
                 .send()
                 .await
-                .map_err(|e| OllamaError::Network(e))?;
+                .map_err(OllamaError::Network)?;
 
             if !response.status().is_success() {
                 return Err(OllamaError::Model(
@@ -126,7 +126,7 @@ impl OllamaClient {
             }
 
             let byte_stream = response.bytes_stream()
-                    .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e));
+                    .map_err(std::io::Error::other);
             let reader = StreamReader::new(byte_stream);
             let mut lines_stream = tokio_stream::wrappers::LinesStream::new(reader.lines());
             while let Some(line) = lines_stream.next().await {

--- a/crates/animus-server/src/main.rs
+++ b/crates/animus-server/src/main.rs
@@ -4,7 +4,8 @@ mod state;
 mod summary_trigger;
 
 use animus_db::{
-    persona_repo::PersonaRepo, summary_repo::SummaryRepo, ConversationRepo, MessageRepo,
+    persona_repo::PersonaRepo, settings_repo::SettingsRepo, summary_repo::SummaryRepo,
+    ConversationRepo, MessageRepo,
 };
 use animus_llm::ollama::OllamaClient;
 use anyhow::Context;
@@ -47,19 +48,34 @@ async fn main() -> anyhow::Result<()> {
     let ollama_url =
         std::env::var("OLLAMA_URL").unwrap_or_else(|_| "http://localhost:11434".to_owned());
     let model_name = std::env::var("OLLAMA_MODEL").unwrap_or_else(|_| "gemma4".to_owned());
+
+    let assets_dir = home.join(".animus/assets").to_string_lossy().into_owned();
+    let backups_dir = home.join(".animus/backups").to_string_lossy().into_owned();
+
+    let settings_repo = SettingsRepo::new(pool.clone());
+    settings_repo
+        .init_defaults(&model_name)
+        .await
+        .context("failed to initialize settings")?;
+
     let app_state = state::AppState {
         personas: PersonaRepo::new(pool.clone()),
         conversations: ConversationRepo::new(pool.clone()),
         messages: MessageRepo::new(pool.clone()),
         summaries: SummaryRepo::new(pool),
-        ollama: OllamaClient::new(ollama_url),
+        settings: settings_repo,
+        ollama: OllamaClient::new(ollama_url.clone()),
         model_name,
+        ollama_url,
+        assets_dir,
+        backups_dir,
     };
 
     let app = routes::personas::router()
         .merge(routes::conversations::router())
         .merge(routes::summary::router())
         .merge(routes::health::router())
+        .merge(routes::settings::router())
         .with_state(app_state);
 
     let listener = tokio::net::TcpListener::bind("0.0.0.0:8082").await?;

--- a/crates/animus-server/src/routes/conversations.rs
+++ b/crates/animus-server/src/routes/conversations.rs
@@ -385,7 +385,8 @@ mod tests {
     use super::*;
     use animus_core::{ContentRating, Persona};
     use animus_db::{
-        persona_repo::PersonaRepo, summary_repo::SummaryRepo, ConversationRepo, MessageRepo,
+        persona_repo::PersonaRepo, settings_repo::SettingsRepo, summary_repo::SummaryRepo,
+        ConversationRepo, MessageRepo,
     };
     use animus_llm::ollama::OllamaClient;
     use axum::{
@@ -402,9 +403,13 @@ mod tests {
             personas: PersonaRepo::new(pool.clone()),
             conversations: ConversationRepo::new(pool.clone()),
             messages: MessageRepo::new(pool.clone()),
-            summaries: SummaryRepo::new(pool),
+            summaries: SummaryRepo::new(pool.clone()),
+            settings: SettingsRepo::new(pool),
             ollama: OllamaClient::new("http://localhost:11434"),
             model_name: "gemma4".to_owned(),
+            ollama_url: "http://localhost:11434".to_owned(),
+            assets_dir: "/tmp/assets".to_owned(),
+            backups_dir: "/tmp/backups".to_owned(),
         };
         router().with_state(state)
     }

--- a/crates/animus-server/src/routes/health.rs
+++ b/crates/animus-server/src/routes/health.rs
@@ -25,7 +25,8 @@ async fn ollama_status(State(state): State<AppState>) -> Json<OllamaStatusRespon
 mod tests {
     use super::*;
     use animus_db::{
-        persona_repo::PersonaRepo, summary_repo::SummaryRepo, ConversationRepo, MessageRepo,
+        persona_repo::PersonaRepo, settings_repo::SettingsRepo, summary_repo::SummaryRepo,
+        ConversationRepo, MessageRepo,
     };
     use animus_llm::ollama::OllamaClient;
     use axum::{body::to_bytes, http::Request};
@@ -39,9 +40,13 @@ mod tests {
             personas: PersonaRepo::new(pool.clone()),
             conversations: ConversationRepo::new(pool.clone()),
             messages: MessageRepo::new(pool.clone()),
-            summaries: SummaryRepo::new(pool),
+            summaries: SummaryRepo::new(pool.clone()),
+            settings: SettingsRepo::new(pool),
             ollama: OllamaClient::new("http://localhost:11434"),
             model_name: "gemma4".to_owned(),
+            ollama_url: "http://localhost:11434".to_owned(),
+            assets_dir: "/tmp/assets".to_owned(),
+            backups_dir: "/tmp/backups".to_owned(),
         };
         router().with_state(state)
     }

--- a/crates/animus-server/src/routes/mod.rs
+++ b/crates/animus-server/src/routes/mod.rs
@@ -1,4 +1,5 @@
 pub mod conversations;
 pub mod health;
 pub mod personas;
+pub mod settings;
 pub mod summary;

--- a/crates/animus-server/src/routes/personas.rs
+++ b/crates/animus-server/src/routes/personas.rs
@@ -390,7 +390,8 @@ impl From<Persona> for PersonaResponse {
 mod tests {
     use super::*;
     use animus_db::{
-        persona_repo::PersonaRepo, summary_repo::SummaryRepo, ConversationRepo, MessageRepo,
+        persona_repo::PersonaRepo, settings_repo::SettingsRepo, summary_repo::SummaryRepo,
+        ConversationRepo, MessageRepo,
     };
     use animus_llm::ollama::OllamaClient;
     use axum::{body::to_bytes, http::Request};
@@ -404,9 +405,13 @@ mod tests {
             personas: PersonaRepo::new(pool.clone()),
             conversations: ConversationRepo::new(pool.clone()),
             messages: MessageRepo::new(pool.clone()),
-            summaries: SummaryRepo::new(pool),
+            summaries: SummaryRepo::new(pool.clone()),
+            settings: SettingsRepo::new(pool),
             ollama: OllamaClient::new("http://localhost:11434"),
             model_name: "gemma4".to_owned(),
+            ollama_url: "http://localhost:11434".to_owned(),
+            assets_dir: "/tmp/assets".to_owned(),
+            backups_dir: "/tmp/backups".to_owned(),
         };
         router().with_state(state)
     }

--- a/crates/animus-server/src/routes/settings.rs
+++ b/crates/animus-server/src/routes/settings.rs
@@ -72,8 +72,8 @@ async fn patch_settings(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use animus_db::{settings_repo::SettingsRepo, ConversationRepo, MessageRepo};
     use animus_db::{persona_repo::PersonaRepo, summary_repo::SummaryRepo};
+    use animus_db::{settings_repo::SettingsRepo, ConversationRepo, MessageRepo};
     use animus_llm::ollama::OllamaClient;
     use axum::{
         body::{to_bytes, Body},
@@ -82,8 +82,7 @@ mod tests {
     use sqlx::SqlitePool;
     use tower::ServiceExt;
 
-    static MIGRATOR: sqlx::migrate::Migrator =
-        sqlx::migrate!("../../crates/animus-db/migrations");
+    static MIGRATOR: sqlx::migrate::Migrator = sqlx::migrate!("../../crates/animus-db/migrations");
 
     fn make_state(pool: SqlitePool) -> AppState {
         AppState {

--- a/crates/animus-server/src/routes/settings.rs
+++ b/crates/animus-server/src/routes/settings.rs
@@ -1,0 +1,199 @@
+use animus_core::AppSettings;
+use axum::{extract::State, response::IntoResponse, routing::get, Json, Router};
+use serde::{Deserialize, Serialize};
+
+use crate::{error::ApiError, state::AppState};
+
+pub fn router() -> Router<AppState> {
+    Router::new().route("/api/settings", get(get_settings).patch(patch_settings))
+}
+
+#[derive(Debug, Serialize)]
+pub struct SettingsResponse {
+    pub user_name: String,
+    pub default_model: String,
+    pub ollama_url: String,
+    pub assets_dir: String,
+    pub backups_dir: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct PatchSettingsRequest {
+    pub user_name: Option<String>,
+    pub default_model: Option<String>,
+}
+
+async fn get_settings(State(state): State<AppState>) -> Result<impl IntoResponse, ApiError> {
+    tracing::debug!(target: "settings", "GET /api/settings");
+    let s = state.settings.get().await.map_err(|_| ApiError::Internal)?;
+    Ok(Json(SettingsResponse {
+        user_name: s.user_name,
+        default_model: s.default_model,
+        ollama_url: state.ollama_url,
+        assets_dir: state.assets_dir,
+        backups_dir: state.backups_dir,
+    }))
+}
+
+async fn patch_settings(
+    State(state): State<AppState>,
+    Json(body): Json<PatchSettingsRequest>,
+) -> Result<impl IntoResponse, ApiError> {
+    tracing::debug!(target: "settings", "PATCH /api/settings");
+
+    if let Some(ref name) = body.user_name {
+        if name.trim().is_empty() {
+            return Err(ApiError::BadRequest("user_name cannot be empty".to_owned()));
+        }
+    }
+
+    let current = state.settings.get().await.map_err(|_| ApiError::Internal)?;
+
+    let updated = AppSettings {
+        user_name: body.user_name.unwrap_or(current.user_name),
+        default_model: body.default_model.unwrap_or(current.default_model),
+    };
+
+    state
+        .settings
+        .upsert(&updated)
+        .await
+        .map_err(|_| ApiError::Internal)?;
+
+    Ok(Json(SettingsResponse {
+        user_name: updated.user_name,
+        default_model: updated.default_model,
+        ollama_url: state.ollama_url,
+        assets_dir: state.assets_dir,
+        backups_dir: state.backups_dir,
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use animus_db::{settings_repo::SettingsRepo, ConversationRepo, MessageRepo};
+    use animus_db::{persona_repo::PersonaRepo, summary_repo::SummaryRepo};
+    use animus_llm::ollama::OllamaClient;
+    use axum::{
+        body::{to_bytes, Body},
+        http::{Method, Request, StatusCode},
+    };
+    use sqlx::SqlitePool;
+    use tower::ServiceExt;
+
+    static MIGRATOR: sqlx::migrate::Migrator =
+        sqlx::migrate!("../../crates/animus-db/migrations");
+
+    fn make_state(pool: SqlitePool) -> AppState {
+        AppState {
+            personas: PersonaRepo::new(pool.clone()),
+            conversations: ConversationRepo::new(pool.clone()),
+            messages: MessageRepo::new(pool.clone()),
+            summaries: SummaryRepo::new(pool.clone()),
+            settings: SettingsRepo::new(pool),
+            ollama: OllamaClient::new("http://localhost:11434".to_owned()),
+            model_name: "gemma4".to_owned(),
+            ollama_url: "http://localhost:11434".to_owned(),
+            assets_dir: "/tmp/assets".to_owned(),
+            backups_dir: "/tmp/backups".to_owned(),
+        }
+    }
+
+    #[sqlx::test(migrator = "MIGRATOR")]
+    async fn get_returns_defaults_on_fresh_db(pool: SqlitePool) {
+        let state = make_state(pool);
+        state.settings.init_defaults("gemma4").await.unwrap();
+
+        let app = router().with_state(state);
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/api/settings")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let bytes = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let body: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(body["user_name"], "User");
+        assert_eq!(body["default_model"], "gemma4");
+        assert_eq!(body["ollama_url"], "http://localhost:11434");
+    }
+
+    #[sqlx::test(migrator = "MIGRATOR")]
+    async fn patch_updates_user_name_and_model(pool: SqlitePool) {
+        let state = make_state(pool);
+        state.settings.init_defaults("gemma4").await.unwrap();
+
+        let app = router().with_state(state);
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method(Method::PATCH)
+                    .uri("/api/settings")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        r#"{"user_name":"Bertrand","default_model":"mistral"}"#,
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let bytes = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let body: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(body["user_name"], "Bertrand");
+        assert_eq!(body["default_model"], "mistral");
+    }
+
+    #[sqlx::test(migrator = "MIGRATOR")]
+    async fn patch_empty_user_name_returns_400(pool: SqlitePool) {
+        let state = make_state(pool);
+        state.settings.init_defaults("gemma4").await.unwrap();
+
+        let app = router().with_state(state);
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method(Method::PATCH)
+                    .uri("/api/settings")
+                    .header("content-type", "application/json")
+                    .body(Body::from(r#"{"user_name":""}"#))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[sqlx::test(migrator = "MIGRATOR")]
+    async fn patch_partial_updates_preserve_other_fields(pool: SqlitePool) {
+        let state = make_state(pool);
+        state.settings.init_defaults("gemma4").await.unwrap();
+
+        let app = router().with_state(state);
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method(Method::PATCH)
+                    .uri("/api/settings")
+                    .header("content-type", "application/json")
+                    .body(Body::from(r#"{"user_name":"Alice"}"#))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let bytes = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let body: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(body["user_name"], "Alice");
+        assert_eq!(body["default_model"], "gemma4", "model must be preserved");
+    }
+}

--- a/crates/animus-server/src/routes/summary.rs
+++ b/crates/animus-server/src/routes/summary.rs
@@ -84,7 +84,8 @@ mod tests {
     use super::*;
     use animus_core::{persona::Summary, ContentRating, Persona};
     use animus_db::{
-        persona_repo::PersonaRepo, summary_repo::SummaryRepo, ConversationRepo, MessageRepo,
+        persona_repo::PersonaRepo, settings_repo::SettingsRepo, summary_repo::SummaryRepo,
+        ConversationRepo, MessageRepo,
     };
     use animus_llm::ollama::OllamaClient;
     use axum::{
@@ -101,9 +102,13 @@ mod tests {
             personas: PersonaRepo::new(pool.clone()),
             conversations: ConversationRepo::new(pool.clone()),
             messages: MessageRepo::new(pool.clone()),
-            summaries: SummaryRepo::new(pool),
+            summaries: SummaryRepo::new(pool.clone()),
+            settings: SettingsRepo::new(pool),
             ollama: OllamaClient::new("http://localhost:11434"),
             model_name: "gemma4".to_owned(),
+            ollama_url: "http://localhost:11434".to_owned(),
+            assets_dir: "/tmp/assets".to_owned(),
+            backups_dir: "/tmp/backups".to_owned(),
         };
         router().with_state(state)
     }

--- a/crates/animus-server/src/state.rs
+++ b/crates/animus-server/src/state.rs
@@ -1,5 +1,6 @@
 use animus_db::{
-    persona_repo::PersonaRepo, summary_repo::SummaryRepo, ConversationRepo, MessageRepo,
+    persona_repo::PersonaRepo, settings_repo::SettingsRepo, summary_repo::SummaryRepo,
+    ConversationRepo, MessageRepo,
 };
 use animus_llm::ollama::OllamaClient;
 
@@ -9,6 +10,10 @@ pub struct AppState {
     pub conversations: ConversationRepo,
     pub messages: MessageRepo,
     pub summaries: SummaryRepo,
+    pub settings: SettingsRepo,
     pub ollama: OllamaClient,
     pub model_name: String,
+    pub ollama_url: String,
+    pub assets_dir: String,
+    pub backups_dir: String,
 }


### PR DESCRIPTION
## Summary

- Adds `app_settings` singleton table (migration 004) with `CHECK id = 1` constraint
- `GET /api/settings` returns mutable fields (`user_name`, `default_model`) + read-only env fields (`ollama_url`, `assets_dir`, `backups_dir`)
- `PATCH /api/settings` updates `user_name` / `default_model`; rejects empty `user_name` with 400
- `OLLAMA_MODEL` env seeds `default_model` on first run only (never overrides existing row)
- Fixes 2 pre-existing clippy lints in `animus-llm::ollama` that were blocking `-D warnings`

## Test plan

- [x] `settings_repo`: `init_defaults` creates row, idempotent on second call, `upsert` updates both fields
- [x] `GET /api/settings` returns defaults on fresh DB
- [x] `PATCH /api/settings` updates `user_name` + `default_model`
- [x] `PATCH /api/settings` with `""` user_name returns 400
- [x] Partial PATCH preserves unchanged fields
- [x] All 75 existing tests still pass
- [x] `cargo clippy --all-targets -- -D warnings` clean

Closes #2