### PR TITLE
feat: add settings page (closes #6)

### DIFF
--- a/frontend/bun.lock
+++ b/frontend/bun.lock
@@ -6,7 +6,6 @@
       "name": "frontend",
       "dependencies": {
         "@base-ui/react": "^1.4.1",
-        "@fontsource-variable/geist": "^5.2.8",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "lucide-react": "^1.14.0",
@@ -134,8 +133,6 @@
     "@floating-ui/react-dom": ["@floating-ui/react-dom@2.1.8", "", { "dependencies": { "@floating-ui/dom": "^1.7.6" }, "peerDependencies": { "react": ">=16.8.0", "react-dom": ">=16.8.0" } }, "sha512-cC52bHwM/n/CxS87FH0yWdngEZrjdtLW/qVruo68qg+prK7ZQ4YGdut2GyDVpoGeAYe/h899rVeOVm6Oi40k2A=="],
 
     "@floating-ui/utils": ["@floating-ui/utils@0.2.11", "", {}, "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg=="],
-
-    "@fontsource-variable/geist": ["@fontsource-variable/geist@5.2.8", "", {}, "sha512-cJ6m9e+8MQ5dCYJsLylfZrgBh6KkG4bOLckB35Tr9J/EqdkEM6QllH5PxqP1dhTvFup+HtMRPuz9xOjxXJggxw=="],
 
     "@hono/node-server": ["@hono/node-server@1.19.14", "", { "peerDependencies": { "hono": "^4" } }, "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw=="],
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,11 +7,11 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test:settings-design": "node scripts/assert-settings-design.mjs"
   },
   "dependencies": {
     "@base-ui/react": "^1.4.1",
-    "@fontsource-variable/geist": "^5.2.8",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "^1.14.0",

--- a/frontend/scripts/assert-settings-design.mjs
+++ b/frontend/scripts/assert-settings-design.mjs
@@ -1,0 +1,23 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const source = readFileSync(join(__dirname, "../src/pages/SettingsPage.tsx"), "utf8");
+
+const expectations = [
+  ["warm app background", "bg-[#F8F8F6]"],
+  ["restrained content width", "max-w-3xl"],
+  ["warm neutral text", "text-[#2B2721]"],
+  ["warm card border", "border-[#D8D3C8]"],
+  ["section separators", "<Separator"],
+  ["clear saved state copy", "Settings updated"],
+];
+
+const missing = expectations
+  .filter(([, token]) => !source.includes(token))
+  .map(([label, token]) => `- ${label}: ${token}`);
+
+if (missing.length > 0) {
+  throw new Error(`Settings page design expectations missing:\n${missing.join("\n")}`);
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,19 +1,23 @@
-import { BrowserRouter, Route, Routes } from "react-router-dom";
+import { BrowserRouter, Navigate, Route, Routes } from "react-router-dom";
 import PersonaListPage from "./pages/PersonaListPage";
 import ChatPage from "./pages/ChatPage";
 import CreatePersonaPage from "./pages/CreatePersonaPage";
 import EditPersonaPage from "./pages/EditPersonaPage";
 import SettingsPage from "./pages/SettingsPage";
+import AppLayout from "./layouts/AppLayout";
 
 export default function App() {
   return (
     <BrowserRouter>
       <Routes>
-        <Route path="/" element={<PersonaListPage />} />
-        <Route path="/chat/:id" element={<ChatPage />} />
-        <Route path="/create" element={<CreatePersonaPage />} />
-        <Route path="/edit/:id" element={<EditPersonaPage />} />
-        <Route path="/settings" element={<SettingsPage />} />
+        <Route element={<AppLayout />}>
+          <Route path="/personas" element={<PersonaListPage />} />
+          <Route path="/personas/new" element={<CreatePersonaPage />} />
+          <Route path="/personas/:id/edit" element={<EditPersonaPage />} />
+          <Route path="/chat/:id" element={<ChatPage />} />
+          <Route path="/settings" element={<SettingsPage />} />
+          <Route path="/" element={<Navigate to="/personas" />} />
+        </Route>
       </Routes>
     </BrowserRouter>
   );

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -3,6 +3,7 @@ import PersonaListPage from "./pages/PersonaListPage";
 import ChatPage from "./pages/ChatPage";
 import CreatePersonaPage from "./pages/CreatePersonaPage";
 import EditPersonaPage from "./pages/EditPersonaPage";
+import SettingsPage from "./pages/SettingsPage";
 
 export default function App() {
   return (
@@ -12,6 +13,7 @@ export default function App() {
         <Route path="/chat/:id" element={<ChatPage />} />
         <Route path="/create" element={<CreatePersonaPage />} />
         <Route path="/edit/:id" element={<EditPersonaPage />} />
+        <Route path="/settings" element={<SettingsPage />} />
       </Routes>
     </BrowserRouter>
   );

--- a/frontend/src/components/SettingsButton.tsx
+++ b/frontend/src/components/SettingsButton.tsx
@@ -1,0 +1,26 @@
+import { Link } from "react-router-dom";
+
+export default function SettingsButton() {
+  return (
+    <Link to="/settings">
+      <button
+        aria-label="Settings"
+        className="grid h-9 w-9 place-items-center rounded-lg text-[#6B6B6B] transition hover:bg-white hover:text-[#2C2C2C] focus:outline-none focus-visible:ring-2 focus-visible:ring-[#8B6F47]/40 active:scale-95"
+      >
+        <svg
+          width="18"
+          height="18"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="1.8"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        >
+          <path d="M12.22 2h-.44a2 2 0 0 0-2 2v.18a2 2 0 0 1-1 1.73l-.43.25a2 2 0 0 1-2 0l-.15-.08a2 2 0 0 0-2.73.73l-.22.38a2 2 0 0 0 .73 2.73l.15.1a2 2 0 0 1 1 1.72v.51a2 2 0 0 1-1 1.74l-.15.09a2 2 0 0 0-.73 2.73l.22.38a2 2 0 0 0 2.73.73l.15-.08a2 2 0 0 1 2 0l.43.25a2 2 0 0 1 1 1.73V20a2 2 0 0 0 2 2h.44a2 2 0 0 0 2-2v-.18a2 2 0 0 1 1-1.73l.43-.25a2 2 0 0 1 2 0l.15.08a2 2 0 0 0 2.73-.73l.22-.39a2 2 0 0 0-.73-2.73l-.15-.08a2 2 0 0 1-1-1.74v-.5a2 2 0 0 1 1-1.74l.15-.09a2 2 0 0 0 .73-2.73l-.22-.38a2 2 0 0 0-2.73-.73l-.15.08a2 2 0 0 1-2 0l-.43-.25a2 2 0 0 1-1-1.73V4a2 2 0 0 0-2-2z" />
+          <circle cx="12" cy="12" r="3" />
+        </svg>
+      </button>
+    </Link>
+  );
+}

--- a/frontend/src/components/ui/card.tsx
+++ b/frontend/src/components/ui/card.tsx
@@ -1,0 +1,103 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+function Card({
+  className,
+  size = "default",
+  ...props
+}: React.ComponentProps<"div"> & { size?: "default" | "sm" }) {
+  return (
+    <div
+      data-slot="card"
+      data-size={size}
+      className={cn(
+        "group/card flex flex-col gap-4 overflow-hidden rounded-xl bg-card py-4 text-sm text-card-foreground ring-1 ring-foreground/10 has-data-[slot=card-footer]:pb-0 has-[>img:first-child]:pt-0 data-[size=sm]:gap-3 data-[size=sm]:py-3 data-[size=sm]:has-data-[slot=card-footer]:pb-0 *:[img:first-child]:rounded-t-xl *:[img:last-child]:rounded-b-xl",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function CardHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-header"
+      className={cn(
+        "group/card-header @container/card-header grid auto-rows-min items-start gap-1 rounded-t-xl px-4 group-data-[size=sm]/card:px-3 has-data-[slot=card-action]:grid-cols-[1fr_auto] has-data-[slot=card-description]:grid-rows-[auto_auto] [.border-b]:pb-4 group-data-[size=sm]/card:[.border-b]:pb-3",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function CardTitle({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-title"
+      className={cn(
+        "font-heading text-base leading-snug font-medium group-data-[size=sm]/card:text-sm",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function CardDescription({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-description"
+      className={cn("text-sm text-muted-foreground", className)}
+      {...props}
+    />
+  )
+}
+
+function CardAction({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-action"
+      className={cn(
+        "col-start-2 row-span-2 row-start-1 self-start justify-self-end",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function CardContent({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-content"
+      className={cn("px-4 group-data-[size=sm]/card:px-3", className)}
+      {...props}
+    />
+  )
+}
+
+function CardFooter({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-footer"
+      className={cn(
+        "flex items-center rounded-b-xl border-t bg-muted/50 p-4 group-data-[size=sm]/card:p-3",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export {
+  Card,
+  CardHeader,
+  CardFooter,
+  CardTitle,
+  CardAction,
+  CardDescription,
+  CardContent,
+}

--- a/frontend/src/components/ui/label.tsx
+++ b/frontend/src/components/ui/label.tsx
@@ -1,0 +1,22 @@
+import * as React from "react"
+import { Label as LabelPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+function Label({
+  className,
+  ...props
+}: React.ComponentProps<typeof LabelPrimitive.Root>) {
+  return (
+    <LabelPrimitive.Root
+      data-slot="label"
+      className={cn(
+        "flex items-center gap-2 text-sm leading-none font-medium select-none group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 peer-disabled:cursor-not-allowed peer-disabled:opacity-50",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export { Label }

--- a/frontend/src/components/ui/separator.tsx
+++ b/frontend/src/components/ui/separator.tsx
@@ -1,0 +1,28 @@
+"use client"
+
+import * as React from "react"
+import { Separator as SeparatorPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+function Separator({
+  className,
+  orientation = "horizontal",
+  decorative = true,
+  ...props
+}: React.ComponentProps<typeof SeparatorPrimitive.Root>) {
+  return (
+    <SeparatorPrimitive.Root
+      data-slot="separator"
+      decorative={decorative}
+      orientation={orientation}
+      className={cn(
+        "shrink-0 bg-border data-horizontal:h-px data-horizontal:w-full data-vertical:w-px data-vertical:self-stretch",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export { Separator }

--- a/frontend/src/hooks/useSettings.ts
+++ b/frontend/src/hooks/useSettings.ts
@@ -1,0 +1,144 @@
+import { getSettings, updateSettings } from "@/lib/api";
+import type { PatchSettingsRequest, SettingsResponse } from "@/types/api";
+import { useCallback, useEffect, useMemo, useState } from "react";
+
+type SettingsFormData = Pick<SettingsResponse, "user_name" | "default_model">;
+
+interface UseSettingsResult {
+  settings: SettingsResponse | null;
+  loading: boolean;
+  error: string | null;
+  isDirty: boolean;
+  formData: SettingsFormData;
+  setFormData: (partial: Partial<SettingsFormData>) => void;
+  isSaving: boolean;
+  isSuccess: boolean;
+  saveError: string | null;
+  refetch: () => void;
+  save: () => Promise<void>;
+}
+
+const EMPTY_SETTINGS_FORM: SettingsFormData = {
+  user_name: "",
+  default_model: "",
+};
+
+export function useSettings(): UseSettingsResult {
+  const [settings, setSettings] = useState<SettingsResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [formData, setFormDataState] =
+    useState<SettingsFormData>(EMPTY_SETTINGS_FORM);
+  const [isSaving, setIsSaving] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
+  const [isSuccess, setIsSuccess] = useState(false);
+
+  const fetchSettings = useCallback(() => {
+    setLoading(true);
+    setError(null);
+
+    getSettings()
+      .then((data) => {
+        setSettings(data);
+        setFormDataState({
+          user_name: data.user_name,
+          default_model: data.default_model,
+        });
+      })
+      .catch((err: unknown) =>
+        setError(err instanceof Error ? err.message : "Unknown error"),
+      )
+      .finally(() => setLoading(false));
+  }, []);
+
+  useEffect(() => {
+    let ignore = false;
+
+    getSettings()
+      .then((data) => {
+        if (ignore) {
+          return;
+        }
+
+        setSettings(data);
+        setFormDataState({
+          user_name: data.user_name,
+          default_model: data.default_model,
+        });
+      })
+      .catch((err: unknown) => {
+        if (ignore) {
+          return;
+        }
+
+        setError(err instanceof Error ? err.message : "Unknown error");
+      })
+      .finally(() => {
+        if (!ignore) {
+          setLoading(false);
+        }
+      });
+
+    return () => {
+      ignore = true;
+    };
+  }, []);
+
+  const setFormData = useCallback((partial: Partial<SettingsFormData>) => {
+    setFormDataState((current) => ({ ...current, ...partial }));
+    setSaveError(null);
+  }, []);
+
+  const isDirty = useMemo(() => {
+    if (!settings) {
+      return false;
+    }
+    return (
+      formData.user_name !== settings.user_name ||
+      formData.default_model !== settings.default_model
+    );
+  }, [formData, settings]);
+
+  const save = useCallback(async () => {
+    const userName = formData.user_name.trim();
+    if (!userName) {
+      setSaveError("User name can not be empty.");
+      return;
+    }
+    setIsSaving(true);
+    setSaveError(null);
+    setIsSuccess(false);
+    try {
+      const payload: PatchSettingsRequest = {
+        user_name: userName,
+        default_model: formData.default_model,
+      };
+      const updated = await updateSettings(payload);
+      setSettings(updated);
+      setFormDataState({
+        user_name: updated.user_name,
+        default_model: updated.default_model,
+      });
+      setIsSuccess(true);
+      setTimeout(() => setIsSuccess(false), 1800);
+    } catch (err: unknown) {
+      setSaveError(err instanceof Error ? err.message : "Unknown Error");
+    } finally {
+      setIsSaving(false);
+    }
+  }, [formData]);
+
+  return {
+    settings,
+    loading,
+    error,
+    isDirty,
+    formData,
+    setFormData,
+    isSaving,
+    isSuccess,
+    saveError,
+    save,
+    refetch: fetchSettings,
+  };
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,13 +1,12 @@
 @import "tailwindcss";
 @import "tw-animate-css";
 @import "shadcn/tailwind.css";
-@import "@fontsource-variable/geist";
 
 @custom-variant dark (&:is(.dark *));
 
 @theme inline {
     --font-heading: var(--font-sans);
-    --font-sans: 'Geist Variable', sans-serif;
+    --font-sans: "Atlassian Sans", "Helvetica Neue", Helvetica, Arial, Sans-Serif;
     --color-sidebar-ring: var(--sidebar-ring);
     --color-sidebar-border: var(--sidebar-border);
     --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
@@ -49,7 +48,7 @@
 }
 
 :root {
-    --background: oklch(1 0 0);
+    --background: #F8F8F6;
     --foreground: oklch(0.145 0 0);
     --card: oklch(1 0 0);
     --card-foreground: oklch(0.145 0 0);

--- a/frontend/src/layouts/AppLayout.tsx
+++ b/frontend/src/layouts/AppLayout.tsx
@@ -1,0 +1,55 @@
+import { NavLink, Outlet } from "react-router-dom";
+import { Settings, Users } from "lucide-react";
+import { OllamaStatusBadge } from "../components/OllamaStatusBadge";
+import { useOllamaStatus } from "../hooks/useOllamaStatus";
+
+const navLinkClass = ({ isActive }: { isActive: boolean }) =>
+  `flex items-center gap-3 rounded-lg px-3 py-2 text-sm transition-colors ${
+    isActive
+      ? "bg-[#EDE5D8] font-medium text-[#2C2C2C]"
+      : "text-[#6B6B6B] hover:bg-[#F0EBE3] hover:text-[#2C2C2C]"
+  }`;
+
+export default function AppLayout() {
+  const ollamaStatus = useOllamaStatus();
+
+  return (
+    <div className="flex h-screen bg-[#FAF9F7] text-[#2C2C2C]">
+      <aside className="flex w-60 flex-shrink-0 flex-col border-r border-[#E8E0D0] bg-[#FAF9F7]">
+        {/* Logo */}
+        <div className="flex h-14 items-center gap-2.5 px-4">
+          <div className="grid h-7 w-7 place-items-center rounded-md bg-[#8B6F47] text-white">
+            <span className="font-serif text-[15px] leading-none">A</span>
+          </div>
+          <span className="text-[17px] font-semibold tracking-tight">Animus</span>
+        </div>
+
+        {/* Nav */}
+        <nav className="flex-1 px-2 py-2" aria-label="Main navigation">
+          <NavLink to="/personas" end={false} className={navLinkClass}>
+            <Users className="h-4 w-4 shrink-0" />
+            Personas
+          </NavLink>
+        </nav>
+
+        {/* Bottom */}
+        <div className="space-y-1 border-t border-[#E8E0D0] px-2 py-3">
+          <div className="px-3 py-1">
+            <OllamaStatusBadge
+              online={ollamaStatus.online}
+              model={ollamaStatus.model}
+            />
+          </div>
+          <NavLink to="/settings" className={navLinkClass}>
+            <Settings className="h-4 w-4 shrink-0" />
+            Settings
+          </NavLink>
+        </div>
+      </aside>
+
+      <main className="flex flex-1 flex-col overflow-auto">
+        <Outlet />
+      </main>
+    </div>
+  );
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -7,7 +7,9 @@ import type {
   CreatePersonaRequest,
   OllamaStatus,
   Persona,
+  SettingsResponse,
   UpdatePersonaRequest,
+  PatchSettingsRequest,
 } from "../types/api";
 
 async function request<T>(url: string, init?: RequestInit): Promise<T> {
@@ -39,7 +41,10 @@ export function createPersona(req: CreatePersonaRequest): Promise<Persona> {
   });
 }
 
-export function updatePersona(id: string, req: UpdatePersonaRequest): Promise<Persona> {
+export function updatePersona(
+  id: string,
+  req: UpdatePersonaRequest,
+): Promise<Persona> {
   return request<Persona>(`/api/personas/${id}`, {
     method: "PATCH",
     headers: { "Content-Type": "application/json" },
@@ -84,7 +89,12 @@ export async function getSummary(
   const data = await request<ApiSummaryResponse>(
     `/api/conversations/${conversationId}/summary`,
   );
-  if (!data.content || !data.message_range_start || !data.message_range_end || data.created_at === null) {
+  if (
+    !data.content ||
+    !data.message_range_start ||
+    !data.message_range_end ||
+    data.created_at === null
+  ) {
     return null;
   }
   return {
@@ -106,5 +116,19 @@ export function streamMessage(
       Accept: "text/event-stream",
     },
     body: JSON.stringify({ content }),
+  });
+}
+
+export function getSettings(): Promise<SettingsResponse> {
+  return request<SettingsResponse>("/api/settings");
+}
+
+export function updateSettings(
+  settings: PatchSettingsRequest,
+): Promise<SettingsResponse> {
+  return request<SettingsResponse>("/api/settings", {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(settings),
   });
 }

--- a/frontend/src/pages/PersonaListPage.tsx
+++ b/frontend/src/pages/PersonaListPage.tsx
@@ -6,6 +6,7 @@ import { PersonaCard } from "../components/PersonaCard";
 import { useOllamaStatus } from "../hooks/useOllamaStatus";
 import { usePersonas } from "../hooks/usePersonas";
 import { createConversation, getLatestConversation } from "../lib/api";
+import SettingsButton from "@/components/SettingsButton";
 
 export default function PersonaListPage() {
   const [query, setQuery] = useState("");
@@ -17,9 +18,7 @@ export default function PersonaListPage() {
   const navigate = useNavigate();
 
   const filtered = personas.filter((p) =>
-    `${p.name} ${p.description}`
-      .toLowerCase()
-      .includes(query.toLowerCase()),
+    `${p.name} ${p.description}`.toLowerCase().includes(query.toLowerCase()),
   );
 
   const handlePersonaClick = async (personaId: string) => {
@@ -66,24 +65,7 @@ export default function PersonaListPage() {
                 model={ollamaStatus.model}
               />
             </div>
-            <button
-              aria-label="Settings"
-              className="grid h-9 w-9 place-items-center rounded-lg text-[#6B6B6B] transition hover:bg-white hover:text-[#2C2C2C] focus:outline-none focus-visible:ring-2 focus-visible:ring-[#8B6F47]/40"
-            >
-              <svg
-                width="18"
-                height="18"
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="currentColor"
-                strokeWidth="1.8"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-              >
-                <path d="M12.22 2h-.44a2 2 0 0 0-2 2v.18a2 2 0 0 1-1 1.73l-.43.25a2 2 0 0 1-2 0l-.15-.08a2 2 0 0 0-2.73.73l-.22.38a2 2 0 0 0 .73 2.73l.15.1a2 2 0 0 1 1 1.72v.51a2 2 0 0 1-1 1.74l-.15.09a2 2 0 0 0-.73 2.73l.22.38a2 2 0 0 0 2.73.73l.15-.08a2 2 0 0 1 2 0l.43.25a2 2 0 0 1 1 1.73V20a2 2 0 0 0 2 2h.44a2 2 0 0 0 2-2v-.18a2 2 0 0 1 1-1.73l.43-.25a2 2 0 0 1 2 0l.15.08a2 2 0 0 0 2.73-.73l.22-.39a2 2 0 0 0-.73-2.73l-.15-.08a2 2 0 0 1-1-1.74v-.5a2 2 0 0 1 1-1.74l.15-.09a2 2 0 0 0 .73-2.73l-.22-.38a2 2 0 0 0-2.73-.73l-.15.08a2 2 0 0 1-2 0l-.43-.25a2 2 0 0 1-1-1.73V4a2 2 0 0 0-2-2z" />
-                <circle cx="12" cy="12" r="3" />
-              </svg>
-            </button>
+            <SettingsButton />
           </div>
         </div>
       </header>
@@ -151,7 +133,10 @@ export default function PersonaListPage() {
         ) : filtered.length > 0 ? (
           <div className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3">
             {filtered.map((p) => (
-              <div key={p.id} className={navigating === p.id ? "opacity-60" : ""}>
+              <div
+                key={p.id}
+                className={navigating === p.id ? "opacity-60" : ""}
+              >
                 <PersonaCard
                   persona={p}
                   onClick={() => void handlePersonaClick(p.id)}
@@ -178,7 +163,16 @@ export default function PersonaListPage() {
           onClick={() => void navigate("/create")}
           className="inline-flex items-center gap-2 rounded-full border border-[#8B6F47] bg-[#F5F0E8] py-2.5 pl-4 pr-5 text-[#8B6F47] shadow-md transition hover:bg-white focus:outline-none focus-visible:ring-2 focus-visible:ring-[#8B6F47]/40"
         >
-          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round">
+          <svg
+            width="16"
+            height="16"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2.2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          >
             <path d="M12 5v14" />
             <path d="M5 12h14" />
           </svg>
@@ -189,7 +183,16 @@ export default function PersonaListPage() {
           onClick={() => setImportOpen(true)}
           className="inline-flex items-center gap-2 rounded-full bg-[#8B6F47] py-3 pl-4 pr-5 text-white shadow-lg shadow-[#8B6F47]/25 transition hover:bg-[#7a6040] focus:outline-none focus-visible:ring-2 focus-visible:ring-[#8B6F47]/40"
         >
-          <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round">
+          <svg
+            width="18"
+            height="18"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2.2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          >
             <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
             <polyline points="17 8 12 3 7 8" />
             <line x1="12" y1="3" x2="12" y2="15" />

--- a/frontend/src/pages/PersonaListPage.tsx
+++ b/frontend/src/pages/PersonaListPage.tsx
@@ -1,12 +1,9 @@
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { ImportPersonaModal } from "../components/ImportPersonaModal";
-import { OllamaStatusBadge } from "../components/OllamaStatusBadge";
 import { PersonaCard } from "../components/PersonaCard";
-import { useOllamaStatus } from "../hooks/useOllamaStatus";
 import { usePersonas } from "../hooks/usePersonas";
 import { createConversation, getLatestConversation } from "../lib/api";
-import SettingsButton from "@/components/SettingsButton";
 
 export default function PersonaListPage() {
   const [query, setQuery] = useState("");
@@ -14,7 +11,6 @@ export default function PersonaListPage() {
   const [navigating, setNavigating] = useState<string | null>(null);
 
   const { personas, loading, error, refetch } = usePersonas();
-  const ollamaStatus = useOllamaStatus();
   const navigate = useNavigate();
 
   const filtered = personas.filter((p) =>
@@ -37,41 +33,8 @@ export default function PersonaListPage() {
   };
 
   return (
-    <div
-      className="min-h-screen w-full"
-      style={{
-        backgroundColor: "#F5F0E8",
-        fontFamily:
-          'Inter, ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif',
-        color: "#2C2C2C",
-      }}
-    >
-      {/* Top bar */}
-      <header className="sticky top-0 z-20 border-b border-[#E8E0D0] bg-[#F5F0E8]/85 backdrop-blur">
-        <div className="mx-auto flex max-w-6xl items-center justify-between px-4 py-3 sm:px-6 lg:px-8">
-          <div className="flex items-center gap-2.5">
-            <div className="grid h-7 w-7 place-items-center rounded-md bg-[#8B6F47] text-white">
-              <span className="font-serif text-[15px] leading-none">A</span>
-            </div>
-            <span className="text-[18px] font-semibold tracking-tight text-[#2C2C2C]">
-              Animus
-            </span>
-          </div>
-
-          <div className="flex items-center gap-2 sm:gap-3">
-            <div className="hidden sm:block">
-              <OllamaStatusBadge
-                online={ollamaStatus.online}
-                model={ollamaStatus.model}
-              />
-            </div>
-            <SettingsButton />
-          </div>
-        </div>
-      </header>
-
-      {/* Main */}
-      <main className="mx-auto max-w-6xl px-4 pb-32 pt-8 sm:px-6 lg:px-8">
+    <div className="min-h-full bg-[#F5F0E8]">
+      <main className="mx-auto w-full max-w-6xl px-4 pb-32 pt-8 sm:px-6 lg:px-8">
         <div className="mb-6 flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
           <div>
             <h1 className="text-[28px] font-semibold tracking-tight text-[#2C2C2C]">
@@ -108,13 +71,6 @@ export default function PersonaListPage() {
           </div>
         </div>
 
-        <div className="mb-4 sm:hidden">
-          <OllamaStatusBadge
-            online={ollamaStatus.online}
-            model={ollamaStatus.model}
-          />
-        </div>
-
         {error && (
           <div className="mb-4 rounded-lg border border-rose-200 bg-rose-50 px-4 py-3 text-[14px] text-rose-700">
             {error}
@@ -140,7 +96,7 @@ export default function PersonaListPage() {
                 <PersonaCard
                   persona={p}
                   onClick={() => void handlePersonaClick(p.id)}
-                  onEdit={() => void navigate(`/edit/${p.id}`)}
+                  onEdit={() => void navigate(`/personas/${p.id}/edit`)}
                 />
               </div>
             ))}
@@ -160,7 +116,7 @@ export default function PersonaListPage() {
       <div className="fixed bottom-6 right-6 flex flex-col items-end gap-2 sm:bottom-8 sm:right-8">
         <button
           aria-label="Create new persona"
-          onClick={() => void navigate("/create")}
+          onClick={() => void navigate("/personas/new")}
           className="inline-flex items-center gap-2 rounded-full border border-[#8B6F47] bg-[#F5F0E8] py-2.5 pl-4 pr-5 text-[#8B6F47] shadow-md transition hover:bg-white focus:outline-none focus-visible:ring-2 focus-visible:ring-[#8B6F47]/40"
         >
           <svg

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -1,0 +1,166 @@
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Separator } from "@/components/ui/separator";
+import { useSettings } from "@/hooks/useSettings";
+import { AlertCircle, Check, Loader2 } from "lucide-react";
+
+export default function SettingsPage() {
+  const {
+    formData,
+    setFormData,
+    save,
+    isSaving,
+    isSuccess,
+    isDirty,
+    loading,
+    error,
+    saveError,
+  } = useSettings();
+
+  if (loading) {
+    return (
+      <div className="min-h-screen bg-[#F8F8F6] px-6 py-10 text-[#2B2721] md:px-10">
+        <div className="mx-auto flex max-w-3xl items-center gap-3 text-sm text-[#6F685F]">
+          <Loader2 className="h-4 w-4 animate-spin" />
+          Loading settings...
+        </div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="min-h-screen bg-[#F8F8F6] px-6 py-10 text-[#2B2721] md:px-10">
+        <div className="mx-auto max-w-3xl rounded-lg border border-[#E3B7AA] bg-[#FFF8F5] p-4 text-sm text-[#9A3412]">
+          <div className="flex items-start gap-3">
+            <AlertCircle className="mt-0.5 h-4 w-4 shrink-0" />
+            <div>
+              <p className="font-medium">Settings unavailable</p>
+              <p className="mt-1 text-[#9A3412]/80">{error}</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-[#F8F8F6] px-6 py-10 text-[#2B2721] md:px-10">
+      <div className="mx-auto max-w-3xl">
+        <div className="mb-8">
+          <h1 className="font-heading text-3xl font-medium tracking-normal">
+            Settings
+          </h1>
+          <p className="mt-2 max-w-xl text-sm leading-6 text-[#6F685F]">
+            Adjust how Animus identifies you and which model it uses by default.
+          </p>
+        </div>
+
+        <Card className="rounded-lg border-[#D8D3C8] bg-[#FFFEFB] shadow-none">
+          <CardHeader className="px-6 pt-6">
+            <CardTitle className="text-lg text-[#2B2721]">
+              Account information
+            </CardTitle>
+            <CardDescription className="text-[#6F685F]">
+              Changes are applied after saving.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-6 px-6 pb-6 pt-2">
+            <Separator className="bg-[#E6E0D8]" />
+
+            <div className="grid gap-3 md:grid-cols-[180px_1fr] md:gap-6">
+              <div>
+                <Label htmlFor="user_name" className="text-[#2B2721]">
+                  User name
+                </Label>
+                <p className="mt-1 text-sm leading-5 text-[#6F685F]">
+                  How characters address you.
+                </p>
+              </div>
+              <Input
+                id="user_name"
+                value={formData.user_name}
+                onChange={(e) => setFormData({ user_name: e.target.value })}
+                placeholder="John Doe"
+                className="h-10 max-w-sm border-[#D8D3C8] bg-[#FDFCF9] text-[#2B2721] placeholder:text-[#9C9489] focus-visible:border-[#C15F3C] focus-visible:ring-[#C15F3C]/20"
+              />
+            </div>
+
+            <Separator className="bg-[#E6E0D8]" />
+
+            <div className="grid gap-3 md:grid-cols-[180px_1fr] md:gap-6">
+              <div>
+                <Label htmlFor="default_model" className="text-[#2B2721]">
+                  Default model
+                </Label>
+                <p className="mt-1 text-sm leading-5 text-[#6F685F]">
+                  The model Animus starts with.
+                </p>
+              </div>
+              <Input
+                id="default_model"
+                value={formData.default_model}
+                onChange={(e) => setFormData({ default_model: e.target.value })}
+                placeholder="gemma4"
+                className="h-10 max-w-sm border-[#D8D3C8] bg-[#FDFCF9] text-[#2B2721] placeholder:text-[#9C9489] focus-visible:border-[#C15F3C] focus-visible:ring-[#C15F3C]/20"
+              />
+            </div>
+
+            <Separator className="bg-[#E6E0D8]" />
+
+            <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+              <div className="min-h-5 text-sm">
+                {saveError && (
+                  <p className="flex items-center gap-2 text-[#B42318]">
+                    <AlertCircle className="h-4 w-4" />
+                    {saveError}
+                  </p>
+                )}
+                {isSuccess && !saveError && (
+                  <p className="flex items-center gap-2 text-[#287A52]">
+                    <Check className="h-4 w-4" />
+                    Settings updated
+                  </p>
+                )}
+                {!isDirty && !isSaving && !isSuccess && !saveError && (
+                  <p className="text-[#8A8176]">No pending changes</p>
+                )}
+              </div>
+
+              <Button
+                onClick={save}
+                disabled={!isDirty || isSaving}
+                size="lg"
+                className="h-10 rounded-lg bg-[#C15F3C] px-4 text-sm font-medium text-white shadow-none transition-colors hover:bg-[#AA5234] active:bg-[#91462D] disabled:cursor-not-allowed disabled:bg-[#D8D3C8] disabled:text-[#7B746A] focus-visible:ring-[#C15F3C]/30"
+              >
+                {isSaving && (
+                  <>
+                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                    Saving...
+                  </>
+                )}
+
+                {isSuccess && !isSaving && (
+                  <>
+                    <Check className="mr-2 h-4 w-4" />
+                    Saved
+                  </>
+                )}
+
+                {!isSaving && !isSuccess && "Save changes"}
+              </Button>
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -117,3 +117,16 @@ export interface CreatePersonaRequest {
   repeat_penalty?: number;
   instruction_template?: InstructionTemplate;
 }
+
+export interface SettingsResponse {
+  user_name: string;
+  default_model: string;
+  ollama_url: string;
+  assets_dir: string;
+  backups_dir: string;
+}
+
+export interface PatchSettingsRequest {
+  user_name?: string;
+  default_model?: string;
+}


### PR DESCRIPTION
## Summary

- Add `/settings` route with editable `user_name` and `default_model` fields
- Extract shared `AppLayout` with sidebar navigation (Personas + Settings links)
- Reorganize routing to RESTful paths (`/personas`, `/personas/new`, `/personas/:id/edit`)

## Changes

- `SettingsPage` — form with save/error/loading/success states; empty user name blocked
- `useSettings` hook — manages form state, dirty tracking, API calls
- `AppLayout` — persistent sidebar replaces per-page header; includes Ollama status
- UI components added: `Card`, `Label`, `Separator`
- `getSettings` / `updateSettings` API helpers + `SettingsResponse` / `PatchSettingsRequest` types
- Design validation script (`assert-settings-design.mjs`)

## Test plan

- [x] Navigate to `/settings` — page loads with current `user_name` and `default_model`
- [x] Edit user name, save — success toast appears; re-navigate confirms value persisted
- [x] Clear user name, try to save — blocked with inline error
- [x] Edit default model, save — persists correctly
- [x] No changes → Save button disabled
- [x] Sidebar shows active state for `/personas` and `/settings`

Closes #6