### PR TITLE
feat(#10): add redo/edit controls in chat UI

### DIFF
--- a/crates/animus-llm/src/ollama.rs
+++ b/crates/animus-llm/src/ollama.rs
@@ -136,6 +136,7 @@ impl OllamaClient {
             let mut lines_stream = tokio_stream::wrappers::LinesStream::new(reader.lines());
             while let Some(line) = lines_stream.next().await {
                 let line = line.map_err(|e| OllamaError::Parse(e.to_string()))?;
+                tracing::trace!(target: "animus_llm::ollama", response_line = %line, "ollama stream line received");
                 let parsed = serde_json::from_str::<OllamaStreamResponse>(&line)
                     .map_err(|e| OllamaError::Parse(e.to_string()))?;
                 if parsed.done {

--- a/crates/animus-server/src/routes/messages.rs
+++ b/crates/animus-server/src/routes/messages.rs
@@ -36,27 +36,88 @@ async fn regenerate_message(
     Path(message_id): Path<Uuid>,
     Json(request): Json<RegenerateMessageRequest>,
 ) -> Result<Response, ApiError> {
+    tracing::info!(
+        target: "animus_server::routes::messages",
+        %message_id,
+        instructions_present = request.instructions.is_some(),
+        "regenerate message request received"
+    );
+
     let message = state
         .messages
         .find_by_id(message_id)
         .await
-        .map_err(|_| ApiError::Internal)?
-        .ok_or(ApiError::NotFound)?;
+        .map_err(|e| {
+            tracing::error!(
+                target: "animus_server::routes::messages",
+                %message_id,
+                error = ?e,
+                "failed to fetch message for regeneration"
+            );
+            ApiError::Internal
+        })?
+        .ok_or_else(|| {
+            tracing::warn!(
+                target: "animus_server::routes::messages",
+                %message_id,
+                "regenerate rejected: message not found"
+            );
+            ApiError::NotFound
+        })?;
+
+    tracing::debug!(
+        target: "animus_server::routes::messages",
+        %message_id,
+        conversation_id = %message.conversation_id,
+        role = %message.role,
+        "message loaded for regeneration"
+    );
 
     let latest_message = state
         .messages
         .find_latest_by_conversation(message.conversation_id)
         .await
-        .map_err(|_| ApiError::Internal)?
-        .ok_or(ApiError::NotFound)?;
+        .map_err(|e| {
+            tracing::error!(
+                target: "animus_server::routes::messages",
+                %message_id,
+                conversation_id = %message.conversation_id,
+                error = ?e,
+                "failed to fetch latest message for regeneration"
+            );
+            ApiError::Internal
+        })?
+        .ok_or_else(|| {
+            tracing::warn!(
+                target: "animus_server::routes::messages",
+                %message_id,
+                conversation_id = %message.conversation_id,
+                "regenerate rejected: conversation has no latest message"
+            );
+            ApiError::NotFound
+        })?;
 
     if message_id != latest_message.id {
+        tracing::warn!(
+            target: "animus_server::routes::messages",
+            %message_id,
+            latest_message_id = %latest_message.id,
+            conversation_id = %message.conversation_id,
+            "regenerate rejected: message is not latest"
+        );
         return Err(ApiError::UnprocessableEntity(
             "only the latest message can be regenerated".to_owned(),
         ));
     }
 
     if message.role != Role::Assistant {
+        tracing::warn!(
+            target: "animus_server::routes::messages",
+            %message_id,
+            conversation_id = %message.conversation_id,
+            role = %message.role,
+            "regenerate rejected: message is not assistant"
+        );
         return Err(ApiError::UnprocessableEntity(
             "only assistant messages can be regenerated".to_owned(),
         ));
@@ -66,7 +127,16 @@ async fn regenerate_message(
         .messages
         .find_before(latest_message.conversation_id, latest_message.id)
         .await
-        .map_err(|_| ApiError::Internal)?;
+        .map_err(|e| {
+            tracing::error!(
+                target: "animus_server::routes::messages",
+                %message_id,
+                conversation_id = %latest_message.conversation_id,
+                error = ?e,
+                "failed to fetch prior messages for regeneration"
+            );
+            ApiError::Internal
+        })?;
 
     let (_, persona) = state
         .conversations
@@ -74,6 +144,7 @@ async fn regenerate_message(
         .await
         .map_err(|e| {
             tracing::error!(
+                target: "animus_server::routes::messages",
                 conversation_id = %latest_message.conversation_id,
                 error = ?e,
                 "failed to fetch conversation with persona"
@@ -84,6 +155,12 @@ async fn regenerate_message(
 
     let mut persona = persona;
     if let Some(instructions) = request.instructions {
+        tracing::debug!(
+            target: "animus_server::routes::messages",
+            %message_id,
+            conversation_id = %latest_message.conversation_id,
+            "using request-specific regeneration instructions"
+        );
         persona.post_history_instructions = instructions;
     }
 
@@ -94,7 +171,12 @@ async fn regenerate_message(
         .ok();
 
     let settings = state.settings.get().await.map_err(|e| {
-        tracing::error!(conversation_id = %latest_message.conversation_id, "failed to fetch settings: {:?}", e);
+        tracing::error!(
+            target: "animus_server::routes::messages",
+            conversation_id = %latest_message.conversation_id,
+            error = ?e,
+            "failed to fetch settings for regeneration"
+        );
         ApiError::Internal
     })?;
 
@@ -112,13 +194,39 @@ async fn regenerate_message(
         num_predict: num_predict_for_char_limits(persona.response_length_limit as u32),
     };
 
+    tracing::info!(
+        target: "animus_server::routes::messages",
+        %message_id,
+        conversation_id = %latest_message.conversation_id,
+        prior_message_count = message_before_target.len(),
+        model = %model,
+        num_predict = options.num_predict,
+        "regeneration validated; opening SSE stream"
+    );
+
     let sse_stream = async_stream::stream! {
         let mut full_text = String::with_capacity(2048);
+        let mut token_count = 0usize;
+        tracing::info!(
+            target: "animus_server::routes::messages",
+            %message_id,
+            conversation_id = %latest_message.conversation_id,
+            model = %model,
+            "ollama stream starting"
+        );
         let mut ollama_stream = Box::pin(state.ollama.stream(&model, prompt, options));
         while let Some(chunk) = ollama_stream.next().await {
             match chunk {
                 Ok(StreamChunk::Token(token)) => {
+                    token_count += 1;
                     full_text.push_str(&token);
+                    tracing::debug!(
+                        target: "animus_server::routes::messages",
+                        %message_id,
+                        token_count,
+                        generated_chars = full_text.len(),
+                        "ollama token received"
+                    );
                     let escaped = serde_json::to_string(&token)
                         .expect("string serialization is infallible");
                     let data = format!(r#"{{"text":{escaped}}}"#);
@@ -127,8 +235,35 @@ async fn regenerate_message(
                     );
                 }
                 Ok(StreamChunk::Done { eval_count: _ }) => {
+                    if full_text.trim().is_empty() {
+                        tracing::warn!(
+                            target: "animus_server::routes::messages",
+                            %message_id,
+                            conversation_id = %latest_message.conversation_id,
+                            token_count,
+                            "ollama completed with empty response; keeping existing message content"
+                        );
+                        let data = serde_json::json!({"message": "empty response from model"}).to_string();
+                        yield Ok(SseEvent::default().event("error").data(data));
+                        return;
+                    }
+
+                    tracing::info!(
+                        target: "animus_server::routes::messages",
+                        %message_id,
+                        conversation_id = %latest_message.conversation_id,
+                        token_count,
+                        generated_chars = full_text.len(),
+                        "ollama stream completed; persisting regenerated message"
+                    );
                     match state.messages.update_content(message_id, latest_message.conversation_id, &full_text).await {
                         Ok(_) => {
+                            tracing::info!(
+                                target: "animus_server::routes::messages",
+                                %message_id,
+                                conversation_id = %latest_message.conversation_id,
+                                "regenerated message persisted"
+                            );
                             let state_for_trigger = state.clone();
                             tokio::spawn(async move {
                                 crate::summary_trigger::evaluate_summary_trigger(latest_message.conversation_id, state_for_trigger).await;
@@ -137,7 +272,13 @@ async fn regenerate_message(
                             yield Ok(SseEvent::default().event("done").data(data));
                         }
                         Err(e) => {
-                            tracing::error!("Failed to persist assistant message: {:?}", e);
+                            tracing::error!(
+                                target: "animus_server::routes::messages",
+                                %message_id,
+                                conversation_id = %latest_message.conversation_id,
+                                error = ?e,
+                                "failed to persist regenerated message"
+                            );
                             let data = serde_json::json!({"message": "Failed to persist message"}).to_string();
                             yield Ok(SseEvent::default().event("error").data(data));
                         }
@@ -145,13 +286,25 @@ async fn regenerate_message(
                     return;
                 }
                 Err(e) => {
-                    tracing::error!("Ollama stream error: {:?}", e);
+                    tracing::error!(
+                        target: "animus_server::routes::messages",
+                        %message_id,
+                        conversation_id = %latest_message.conversation_id,
+                        error = ?e,
+                        "ollama stream error during regeneration"
+                    );
                     let data = r#"{"message":"stream error"}"#.to_owned();
                     yield Ok(SseEvent::default().event("error").data(data));
                     return;
                 }
             }
         }
+        tracing::warn!(
+            target: "animus_server::routes::messages",
+            %message_id,
+            conversation_id = %latest_message.conversation_id,
+            "ollama stream ended without done event"
+        );
     };
 
     Ok(Sse::new(sse_stream).into_response())
@@ -162,20 +315,54 @@ async fn edit_message(
     Path(message_id): Path<Uuid>,
     Json(request): Json<EditMessageRequest>,
 ) -> Result<impl IntoResponse, ApiError> {
+    tracing::info!(
+        target: "animus_server::routes::messages",
+        %message_id,
+        edited_chars = request.content.len(),
+        "edit message request received"
+    );
+
     let message = state
         .messages
         .find_by_id(message_id)
         .await
-        .map_err(|_| ApiError::Internal)?
-        .ok_or(ApiError::NotFound)?;
+        .map_err(|e| {
+            tracing::error!(
+                target: "animus_server::routes::messages",
+                %message_id,
+                error = ?e,
+                "failed to fetch message for edit"
+            );
+            ApiError::Internal
+        })?
+        .ok_or_else(|| {
+            tracing::warn!(
+                target: "animus_server::routes::messages",
+                %message_id,
+                "edit rejected: message not found"
+            );
+            ApiError::NotFound
+        })?;
 
     if request.content.is_empty() {
+        tracing::warn!(
+            target: "animus_server::routes::messages",
+            %message_id,
+            "edit rejected: empty content"
+        );
         return Err(ApiError::UnprocessableEntity(
             "content must not be empty".to_owned(),
         ));
     }
 
     if message.role != Role::Assistant {
+        tracing::warn!(
+            target: "animus_server::routes::messages",
+            %message_id,
+            conversation_id = %message.conversation_id,
+            role = %message.role,
+            "edit rejected: message is not assistant"
+        );
         return Err(ApiError::UnprocessableEntity(
             "only assistant messages can be edited".to_owned(),
         ));
@@ -185,10 +372,34 @@ async fn edit_message(
         .messages
         .find_latest_by_conversation(message.conversation_id)
         .await
-        .map_err(|_| ApiError::Internal)?
-        .ok_or(ApiError::NotFound)?;
+        .map_err(|e| {
+            tracing::error!(
+                target: "animus_server::routes::messages",
+                %message_id,
+                conversation_id = %message.conversation_id,
+                error = ?e,
+                "failed to fetch latest message for edit"
+            );
+            ApiError::Internal
+        })?
+        .ok_or_else(|| {
+            tracing::warn!(
+                target: "animus_server::routes::messages",
+                %message_id,
+                conversation_id = %message.conversation_id,
+                "edit rejected: conversation has no latest message"
+            );
+            ApiError::NotFound
+        })?;
 
     if message_id != latest_message.id {
+        tracing::warn!(
+            target: "animus_server::routes::messages",
+            %message_id,
+            latest_message_id = %latest_message.id,
+            conversation_id = %message.conversation_id,
+            "edit rejected: message is not latest"
+        );
         return Err(ApiError::UnprocessableEntity(
             "only latest message can be edited".to_owned(),
         ));
@@ -198,7 +409,24 @@ async fn edit_message(
         .messages
         .update_content(message_id, message.conversation_id, &request.content)
         .await
-        .map_err(|_| ApiError::Internal)?;
+        .map_err(|e| {
+            tracing::error!(
+                target: "animus_server::routes::messages",
+                %message_id,
+                conversation_id = %message.conversation_id,
+                error = ?e,
+                "failed to persist edited message"
+            );
+            ApiError::Internal
+        })?;
+
+    tracing::info!(
+        target: "animus_server::routes::messages",
+        message_id = %updated_message.id,
+        conversation_id = %updated_message.conversation_id,
+        edited_chars = updated_message.content.len(),
+        "message edited successfully"
+    );
 
     Ok(Json(updated_message))
 }
@@ -559,6 +787,59 @@ mod tests {
         assert_eq!(messages_after_regenerate.len(), 1);
         assert_eq!(messages_after_regenerate[0].id, original_message_id);
         assert_eq!(messages_after_regenerate[0].content, "regenerated text");
+    }
+
+    #[sqlx::test(migrator = "MIGRATOR")]
+    async fn regenerate_empty_ollama_response_does_not_overwrite_message(pool: SqlitePool) {
+        let ollama_url = spawn_ollama_stub("").await;
+        let persona = insert_persona(&pool, "Alice", "Hello, I am {{char}}").await;
+        let message_repo = MessageRepo::new(pool.clone());
+        let app = make_app_with_ollama_url(pool.clone(), &ollama_url);
+
+        let res = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/conversations")
+                    .header("content-type", "application/json")
+                    .body(Body::from(format!(r#"{{"persona_id":"{}"}}"#, persona.id)))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(res.status(), StatusCode::CREATED);
+
+        let created = body_json(res).await;
+        let conversation_id = Uuid::parse_str(created["id"].as_str().unwrap()).unwrap();
+        let messages = message_repo.find_last_n(conversation_id, 10).await.unwrap();
+        let original_message = messages.first().unwrap().clone();
+
+        let regenerate = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri(format!("/api/messages/{}/regenerate", original_message.id))
+                    .header("content-type", "application/json")
+                    .body(Body::from(r#"{}"#))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(regenerate.status(), StatusCode::OK);
+        let response_body = to_bytes(regenerate.into_body(), usize::MAX).await.unwrap();
+        let response_body = String::from_utf8(response_body.to_vec()).unwrap();
+        assert!(response_body.contains(r#"event: error"#));
+        assert!(response_body.contains("empty response"));
+
+        let message_after_regenerate = message_repo
+            .find_by_id(original_message.id)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(message_after_regenerate.content, original_message.content);
     }
 
     #[sqlx::test(migrator = "MIGRATOR")]

--- a/frontend/src/hooks/useStreamingMessage.ts
+++ b/frontend/src/hooks/useStreamingMessage.ts
@@ -1,13 +1,16 @@
 import { useCallback, useEffect, useRef, useState } from "react";
-import { streamMessage } from "../lib/api";
+import { regenerateMessage, streamMessage } from "../lib/api";
 import type { Message } from "../types/api";
 
 interface UseStreamingMessageResult {
   messages: Message[];
   streamingText: string;
+  streamingMessageId: string | null;
   isStreaming: boolean;
   error: string | null;
   sendMessage: (content: string) => void;
+  redoMessage: (messageId: string, instructions?: string) => void;
+  updateMessageContent: (messageId: string, content: string) => void;
 }
 
 async function parseSSEStream(
@@ -77,6 +80,7 @@ export function useStreamingMessage(
 ): UseStreamingMessageResult {
   const [messages, setMessages] = useState<Message[]>(initialMessages);
   const [streamingText, setStreamingText] = useState("");
+  const [streamingMessageId, setStreamingMessageId] = useState<string | null>(null);
   const [isStreaming, setIsStreaming] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const hydrated = useRef(false);
@@ -143,5 +147,72 @@ export function useStreamingMessage(
     [conversationId],
   );
 
-  return { messages, streamingText, isStreaming, error, sendMessage };
+  const redoMessage = useCallback(
+    async (messageId: string, instructions?: string) => {
+      setError(null);
+      setStreamingText("");
+      setStreamingMessageId(messageId);
+      setIsStreaming(true);
+
+      let fullText = "";
+
+      try {
+        const res = await regenerateMessage(messageId, instructions);
+        if (!res.ok || !res.body) {
+          throw new Error(`${res.status}: ${res.statusText}`);
+        }
+
+        const reader = res.body.getReader();
+
+        await parseSSEStream(
+          reader,
+          (text) => {
+            fullText += text;
+            setStreamingText((prev) => prev + text);
+          },
+          () => {
+            setMessages((prev) =>
+              prev.map((m) =>
+                m.id === messageId ? { ...m, content: fullText } : m,
+              ),
+            );
+            setStreamingText("");
+            setStreamingMessageId(null);
+            setIsStreaming(false);
+          },
+          (errorMessage) => {
+            setError(errorMessage);
+            setStreamingMessageId(null);
+            setIsStreaming(false);
+          },
+        );
+      } catch (err) {
+        const message = err instanceof Error ? err.message : "Unknown error";
+        setError(message);
+        setStreamingMessageId(null);
+        setIsStreaming(false);
+      }
+    },
+    [],
+  );
+
+  const updateMessageContent = useCallback(
+    (messageId: string, content: string) => {
+      setMessages((prev) =>
+        prev.map((m) => (m.id === messageId ? { ...m, content } : m)),
+      );
+    },
+    [],
+  );
+
+  return {
+    messages,
+    streamingText,
+    streamingMessageId,
+    isStreaming,
+    error,
+    sendMessage,
+    redoMessage,
+    updateMessageContent,
+  };
 }

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -119,6 +119,34 @@ export function streamMessage(
   });
 }
 
+export function regenerateMessage(
+  messageId: string,
+  instructions?: string,
+): Promise<Response> {
+  return fetch(`/api/messages/${messageId}/regenerate`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Accept: "text/event-stream",
+    },
+    body: JSON.stringify({ instructions: instructions ?? null }),
+  });
+}
+
+export function editMessage(
+  messageId: string,
+  content: string,
+): Promise<{ id: string; role: string; content: string }> {
+  return request<{ id: string; role: string; content: string }>(
+    `/api/messages/${messageId}`,
+    {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ content }),
+    },
+  );
+}
+
 export function getSettings(): Promise<SettingsResponse> {
   return request<SettingsResponse>("/api/settings");
 }

--- a/frontend/src/pages/ChatPage.tsx
+++ b/frontend/src/pages/ChatPage.tsx
@@ -1,9 +1,11 @@
 import { useEffect, useRef, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import ReactMarkdown from "react-markdown";
-import { getConversation, getPersonaById } from "../lib/api";
+import { editMessage, getConversation, getPersonaById } from "../lib/api";
 import { useStreamingMessage } from "../hooks/useStreamingMessage";
 import { SummaryDrawer } from "./SummaryDrawer";
+import { Button } from "../components/ui/button";
+import { Textarea } from "../components/ui/textarea";
 import type { Message, Persona } from "../types/api";
 
 function nameToHue(name: string): number {
@@ -112,18 +114,100 @@ function BlinkingCursor() {
   );
 }
 
+function MessageControls({
+  onRedo,
+  onRedoWithNote,
+  onEdit,
+  disabled,
+}: {
+  onRedo: () => void;
+  onRedoWithNote: () => void;
+  onEdit: () => void;
+  disabled: boolean;
+}) {
+  const btnClass =
+    "inline-flex items-center gap-1 rounded-md px-2 py-1 text-[11px] font-medium text-[#6B6B6B] transition hover:bg-white hover:text-[#8B6F47] disabled:pointer-events-none disabled:opacity-40 focus:outline-none focus-visible:ring-2 focus-visible:ring-[#8B6F47]/40";
+  return (
+    <div className="mt-1 flex items-center gap-0.5">
+      <button type="button" className={btnClass} onClick={onRedo} disabled={disabled} aria-label="Regenerate response">
+        <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round">
+          <path d="M3 12a9 9 0 1 0 9-9 9.75 9.75 0 0 0-6.74 2.74L3 8" />
+          <path d="M3 3v5h5" />
+        </svg>
+        Redo
+      </button>
+      <button type="button" className={btnClass} onClick={onRedoWithNote} disabled={disabled} aria-label="Regenerate with instruction">
+        <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round">
+          <path d="M3 12a9 9 0 1 0 9-9 9.75 9.75 0 0 0-6.74 2.74L3 8" />
+          <path d="M3 3v5h5" />
+          <path d="M12 8v4l3 3" />
+        </svg>
+        Redo with note
+      </button>
+      <button type="button" className={btnClass} onClick={onEdit} disabled={disabled} aria-label="Edit response">
+        <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round">
+          <path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7" />
+          <path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4Z" />
+        </svg>
+        Edit
+      </button>
+    </div>
+  );
+}
+
 function MessageRow({
   message,
   isStreaming,
+  streamingContent,
   personaHue,
   personaName,
+  isLatestAssistant,
+  controlsDisabled,
+  onRedo,
+  onRedoWithNote,
+  onEditSave,
 }: {
   message: { id: string; role: "user" | "assistant"; content: string };
   isStreaming: boolean;
+  streamingContent?: string;
   personaHue: number;
   personaName: string;
+  isLatestAssistant?: boolean;
+  controlsDisabled?: boolean;
+  onRedo?: () => void;
+  onRedoWithNote?: () => void;
+  onEditSave?: (content: string) => Promise<void>;
 }) {
+  const [isEditing, setIsEditing] = useState(false);
+  const [editDraft, setEditDraft] = useState("");
+  const [editSaving, setEditSaving] = useState(false);
+
+  const handleEditStart = () => {
+    setEditDraft(message.content);
+    setIsEditing(true);
+  };
+
+  const handleEditCancel = () => {
+    setIsEditing(false);
+    setEditDraft("");
+  };
+
+  const handleEditSave = async () => {
+    if (!onEditSave || !editDraft.trim()) return;
+    setEditSaving(true);
+    try {
+      await onEditSave(editDraft.trim());
+      setIsEditing(false);
+      setEditDraft("");
+    } finally {
+      setEditSaving(false);
+    }
+  };
+
+  const displayContent = streamingContent !== undefined ? streamingContent : message.content;
+  const showCursor = isStreaming;
   const isUser = message.role === "user";
+
   return (
     <div className={`flex w-full ${isUser ? "justify-end" : "justify-start"}`}>
       {!isUser && (
@@ -132,32 +216,76 @@ function MessageRow({
         </div>
       )}
       <div
-        className={`flex max-w-[78%] flex-col ${isUser ? "items-end" : "items-start"}`}
+        className={`flex flex-col ${isEditing ? "w-full max-w-[92%]" : "max-w-[78%]"} ${isUser ? "items-end" : "items-start"}`}
       >
-        <div
-          className={[
-            "rounded-xl px-4 py-2.5 text-[14.5px] leading-relaxed shadow-sm",
-            isUser
-              ? "bg-[#8B6F47] text-white rounded-br-sm"
-              : "bg-white border border-[#E8E0D0] text-[#2C2C2C] rounded-bl-sm",
-          ].join(" ")}
-        >
-          <ReactMarkdown
-            components={{
-              p: ({ children }) => (
-                <p className="whitespace-pre-wrap m-0" style={{ textWrap: "pretty" }}>
-                  {children}
-                  {isStreaming && <BlinkingCursor />}
-                </p>
-              ),
-              em: ({ children }) => (
-                <em className={isUser ? "opacity-80" : "text-[#6B6B6B]"}>{children}</em>
-              ),
-            }}
+        {isEditing ? (
+          <div className="w-full">
+            <Textarea
+              value={editDraft}
+              onChange={(e) => setEditDraft(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Escape") handleEditCancel();
+                if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) handleEditSave();
+              }}
+              className="text-[14.5px] leading-relaxed"
+              autoFocus
+              disabled={editSaving}
+            />
+            <div className="mt-2 flex items-center gap-1.5">
+              <Button
+                size="sm"
+                onClick={handleEditSave}
+                disabled={editSaving || !editDraft.trim()}
+              >
+                {editSaving ? "Saving…" : "Save"}
+              </Button>
+              <Button
+                size="sm"
+                variant="outline"
+                onClick={handleEditCancel}
+                disabled={editSaving}
+              >
+                Cancel
+              </Button>
+              <span className="ml-1 text-[11px] text-[#C9BCA6]">
+                <kbd className="rounded border border-[#E8E0D0] bg-[#F5F0E8] px-1 py-0.5 font-mono text-[10px]">⌘↵</kbd> save
+              </span>
+            </div>
+          </div>
+        ) : (
+          <div
+            className={[
+              "rounded-xl px-4 py-2.5 text-[14.5px] leading-relaxed shadow-sm",
+              isUser
+                ? "bg-[#8B6F47] text-white rounded-br-sm"
+                : "bg-white border border-[#E8E0D0] text-[#2C2C2C] rounded-bl-sm",
+            ].join(" ")}
           >
-            {message.content}
-          </ReactMarkdown>
-        </div>
+            <ReactMarkdown
+              components={{
+                p: ({ children }) => (
+                  <p className="whitespace-pre-wrap m-0" style={{ textWrap: "pretty" }}>
+                    {children}
+                    {showCursor && <BlinkingCursor />}
+                  </p>
+                ),
+                em: ({ children }) => (
+                  <em className={isUser ? "opacity-80" : "text-[#6B6B6B]"}>{children}</em>
+                ),
+              }}
+            >
+              {displayContent}
+            </ReactMarkdown>
+          </div>
+        )}
+        {isLatestAssistant && !isEditing && onRedo && onRedoWithNote && onEditSave && (
+          <MessageControls
+            onRedo={onRedo}
+            onRedoWithNote={onRedoWithNote}
+            onEdit={handleEditStart}
+            disabled={controlsDisabled ?? false}
+          />
+        )}
       </div>
     </div>
   );
@@ -243,6 +371,128 @@ function ComposerSendButton({
   );
 }
 
+type ToastState = { text: string; id: number; persistent: boolean };
+
+function Toast({ toast }: { toast: ToastState | null }) {
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    setVisible(!!toast);
+  }, [toast]);
+
+  if (!toast) return null;
+
+  const isSuccess = !toast.persistent;
+
+  return (
+    <div
+      aria-live="polite"
+      className={[
+        "fixed bottom-20 left-1/2 z-50 -translate-x-1/2 transition-all duration-300",
+        visible ? "translate-y-0 opacity-100" : "translate-y-2 opacity-0",
+      ].join(" ")}
+    >
+      <div
+        className={[
+          "flex items-center gap-2 rounded-full border px-4 py-2 text-[12.5px] font-medium shadow-lg backdrop-blur-sm",
+          isSuccess
+            ? "border-[#5d8f22]/30 bg-[#76AD2B] text-white"
+            : "border-white/10 bg-[#2C2C2C]/85 text-white",
+        ].join(" ")}
+      >
+        {toast.persistent ? (
+          <span
+            className="inline-block h-3 w-3 rounded-full border-2 border-white/30 border-t-white"
+            style={{ animation: "animus-spin 0.8s linear infinite" }}
+            aria-hidden="true"
+          />
+        ) : (
+          <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+            <path d="M20 6 9 17l-5-5" />
+          </svg>
+        )}
+        {toast.text}
+      </div>
+    </div>
+  );
+}
+
+function useToast() {
+  const [toast, setToast] = useState<ToastState | null>(null);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const showToast = (text: string, persistent = false) => {
+    if (timerRef.current) clearTimeout(timerRef.current);
+    const id = Date.now();
+    setToast({ text, id, persistent });
+    if (!persistent) {
+      timerRef.current = setTimeout(() => setToast(null), 2800);
+    }
+  };
+
+  const dismissToast = () => {
+    if (timerRef.current) clearTimeout(timerRef.current);
+    setToast(null);
+  };
+
+  return { toast, showToast, dismissToast };
+}
+
+function RedoWithNoteDialog({
+  open,
+  onClose,
+  onConfirm,
+}: {
+  open: boolean;
+  onClose: () => void;
+  onConfirm: (note: string) => void;
+}) {
+  const [note, setNote] = useState("");
+
+  const handleConfirm = () => {
+    onConfirm(note.trim());
+    setNote("");
+  };
+
+  const handleClose = () => {
+    setNote("");
+    onClose();
+  };
+
+  if (!open) return null;
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center"
+      onClick={(e) => { if (e.target === e.currentTarget) handleClose(); }}
+    >
+      <div className="absolute inset-0 bg-[#2C2C2C]/30 backdrop-blur-sm" aria-hidden="true" />
+      <div className="relative z-10 w-full max-w-sm rounded-2xl border border-[#E8E0D0] bg-[#F5F0E8] p-5 shadow-xl">
+        <div className="mb-3 text-[14px] font-semibold text-[#2C2C2C]">Redo with note</div>
+        <p className="mb-3 text-[12.5px] leading-relaxed text-[#6B6B6B]">
+          Add a temporary instruction that will guide the regenerated response.
+        </p>
+        <textarea
+          value={note}
+          onChange={(e) => setNote(e.target.value)}
+          placeholder="e.g. Make it shorter and more playful…"
+          className="w-full rounded-xl border border-[#E8E0D0] bg-white px-3 py-2 text-[13.5px] leading-relaxed text-[#2C2C2C] placeholder:text-[#6B6B6B] focus:border-[#8B6F47] focus:outline-none focus-visible:ring-2 focus-visible:ring-[#8B6F47]/20 resize-none"
+          rows={3}
+          autoFocus
+          onKeyDown={(e) => {
+            if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) handleConfirm();
+            if (e.key === "Escape") handleClose();
+          }}
+        />
+        <div className="mt-3 flex justify-end gap-2">
+          <Button variant="outline" size="sm" onClick={handleClose}>Cancel</Button>
+          <Button size="sm" onClick={handleConfirm}>Redo</Button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
 export default function ChatPage() {
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
@@ -252,11 +502,20 @@ export default function ChatPage() {
   const [input, setInput] = useState("");
   const [portraitCompact, setPortraitCompact] = useState(false);
   const [summaryOpen, setSummaryOpen] = useState(false);
+  const [redoWithNoteOpen, setRedoWithNoteOpen] = useState(false);
   const [initialMessages, setInitialMessages] = useState<Message[]>([]);
   const scrollRef = useRef<HTMLDivElement>(null);
+  const { toast, showToast } = useToast();
 
-  const { messages, streamingText, isStreaming, sendMessage } =
-    useStreamingMessage(id || "", initialMessages);
+  const {
+    messages,
+    streamingText,
+    streamingMessageId,
+    isStreaming,
+    sendMessage,
+    redoMessage,
+    updateMessageContent,
+  } = useStreamingMessage(id || "", initialMessages);
 
   useEffect(() => {
     if (!id) {
@@ -284,6 +543,15 @@ export default function ChatPage() {
     const el = scrollRef.current;
     if (el) el.scrollTop = el.scrollHeight;
   }, [messages, streamingText]);
+
+  const prevStreamingMessageIdRef = useRef<string | null>(null);
+  useEffect(() => {
+    const prev = prevStreamingMessageIdRef.current;
+    if (prev !== null && streamingMessageId === null) {
+      showToast("Response regenerated");
+    }
+    prevStreamingMessageIdRef.current = streamingMessageId;
+  }, [streamingMessageId]);
 
   if (loading) {
     return (
@@ -317,11 +585,33 @@ export default function ChatPage() {
           linear-gradient(180deg, #F5F0E8 0%, #ECE3D2 100%)`,
       };
 
+  const latestAssistantId =
+    [...messages].reverse().find((m) => m.role === "assistant")?.id ?? null;
+
   const handleSend = () => {
     const trimmed = input.trim();
     if (!trimmed || isStreaming) return;
     sendMessage(trimmed);
     setInput("");
+  };
+
+  const handleRedo = () => {
+    if (!latestAssistantId || isStreaming) return;
+    showToast("Regenerating…", true);
+    redoMessage(latestAssistantId);
+  };
+
+  const handleRedoWithNote = (note: string) => {
+    if (!latestAssistantId || isStreaming) return;
+    showToast("Regenerating…", true);
+    redoMessage(latestAssistantId, note || undefined);
+    setRedoWithNoteOpen(false);
+  };
+
+  const handleEditSave = async (messageId: string, content: string) => {
+    await editMessage(messageId, content);
+    updateMessageContent(messageId, content);
+    showToast("Message edited");
   };
 
   return (
@@ -333,7 +623,7 @@ export default function ChatPage() {
         color: "#2C2C2C",
       }}
     >
-      <style>{`@keyframes animus-blink { 50% { opacity: 0; } }`}</style>
+      <style>{`@keyframes animus-blink { 50% { opacity: 0; } } @keyframes animus-spin { to { transform: rotate(360deg); } }`}</style>
 
       <div
         className="pointer-events-none absolute inset-0"
@@ -461,16 +751,26 @@ export default function ChatPage() {
                   Today
                 </span>
               </div>
-              {messages.map((m) => (
-                <MessageRow
-                  key={m.id}
-                  message={m}
-                  isStreaming={false}
-                  personaHue={personaHue}
-                  personaName={persona.name}
-                />
-              ))}
-              {streamingText && (
+              {messages.map((m) => {
+                const isLatest = m.id === latestAssistantId && m.role === "assistant";
+                const isRedoing = m.id === streamingMessageId;
+                return (
+                  <MessageRow
+                    key={m.id}
+                    message={m}
+                    isStreaming={isRedoing}
+                    streamingContent={isRedoing ? streamingText : undefined}
+                    personaHue={personaHue}
+                    personaName={persona.name}
+                    isLatestAssistant={isLatest && !streamingMessageId}
+                    controlsDisabled={isStreaming}
+                    onRedo={isLatest ? handleRedo : undefined}
+                    onRedoWithNote={isLatest ? () => setRedoWithNoteOpen(true) : undefined}
+                    onEditSave={isLatest ? (content) => handleEditSave(m.id, content) : undefined}
+                  />
+                );
+              })}
+              {streamingText && !streamingMessageId && (
                 <MessageRow
                   message={{
                     id: "streaming",
@@ -538,6 +838,12 @@ export default function ChatPage() {
         conversationId={id || ""}
         personaName={persona.name}
       />
+      <RedoWithNoteDialog
+        open={redoWithNoteOpen}
+        onClose={() => setRedoWithNoteOpen(false)}
+        onConfirm={handleRedoWithNote}
+      />
+      <Toast toast={toast} />
     </div>
   );
 }


### PR DESCRIPTION
## Summary

- **Backend**: structured tracing on all `messages` route paths, empty-response guard for regeneration (emits SSE error instead of overwriting), new coverage test
- **Frontend**: redo / redo-with-note / inline-edit controls on the latest assistant message; shadcn `Textarea` + `Button` for edit mode; toast notifications (green on success, dark spinner while streaming)

## Changes

### Backend (`crates/`)
- Structured `tracing` with targets on all error/warn/info paths in `regenerate_message` and `edit_message`
- Guard: if Ollama returns empty text, SSE `error` event fires — existing message content preserved
- New test: `regenerate_empty_ollama_response_does_not_overwrite_message`
- `ollama.rs`: trace-level log per raw stream line

### Frontend (`frontend/src/`)
- `api.ts`: `regenerateMessage(id, instructions?)` (SSE fetch) + `editMessage(id, content)` (PATCH)
- `useStreamingMessage`: `redoMessage` streams regeneration in-place via `streamingMessageId`; `updateMessageContent` for local state sync after edit
- `ChatPage`: `MessageControls` (Redo / Redo with note / Edit) — only on latest assistant message, disabled while streaming
- Edit mode: shadcn `Textarea` (auto-resize via `field-sizing-content`) + `Button`; ⌘↵ to save, Esc to cancel
- `RedoWithNoteDialog`: modal with temporary instruction input
- `Toast`: green `#76AD2B` + checkmark for success, dark pill + spinner for in-progress regeneration

## Test plan

- [x] Send a message, verify Redo / Redo with note / Edit controls appear only on the latest assistant message
- [x] Redo: spinner toast during stream, green toast on completion, message content updated in-place
- [x] Redo with note: dialog accepts instruction, same streaming behaviour
- [x] Edit: textarea auto-expands to full content, Save updates message, Cancel reverts
- [x] Controls disabled while any stream is active
- [x] Backend: `cargo test --all` passes

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)