### PR TITLE
Store persona avatars and backgrounds as local files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -69,6 +69,7 @@ dependencies = [
  "anyhow",
  "async-stream",
  "axum",
+ "base64",
  "dirs",
  "dotenvy",
  "futures",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -75,6 +75,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sqlx",
+ "tempfile",
  "tokio",
  "tower 0.4.13",
  "tracing",

--- a/TODO.md
+++ b/TODO.md
@@ -1,3 +1,6 @@
 # TODO
 
 - [ ] Add a popup alert in `frontend/src/components/persona-form/PersonaFormFields.tsx`, or the closest appropriate frontend component, to inform the user that the template instruction is updated when changing a persona's content rating.
+- [ ] Add a time informations in chatpage to know how long did it takes to generate the message.
+- [ ] Clean les logs automatiquement après une certaine ancienneté
+- [ ]

--- a/crates/animus-server/Cargo.toml
+++ b/crates/animus-server/Cargo.toml
@@ -23,4 +23,5 @@ async-stream = { workspace = true }
 dirs = "6.0.0"
 
 [dev-dependencies]
+tempfile = "3"
 tower = { version = "0.4", features = ["util"] }

--- a/crates/animus-server/Cargo.toml
+++ b/crates/animus-server/Cargo.toml
@@ -8,6 +8,7 @@ animus-core = { path = "../animus-core" }
 animus-db = { path = "../animus-db" }
 animus-llm = { path = "../animus-llm" }
 axum = { version = "0.7" }
+base64 = "0.22.1"
 dotenvy = "0.15"
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/animus-server/src/assets.rs
+++ b/crates/animus-server/src/assets.rs
@@ -4,6 +4,7 @@ use std::{
     path::{Path, PathBuf},
 };
 
+use base64::{engine::general_purpose, Engine as _};
 use uuid::Uuid;
 
 pub enum AssetKind {
@@ -40,6 +41,28 @@ pub fn save_persona_asset(
     Ok(full_path)
 }
 
+pub fn parse_data_uri(uri: &str) -> Option<(String, Vec<u8>)> {
+    if !uri.starts_with("data:") {
+        return None;
+    }
+
+    let (header, data) = uri.split_once(";base64,")?;
+
+    let mime_type = header.strip_prefix("data:")?;
+
+    let bytes: Vec<u8> = general_purpose::STANDARD.decode(data).ok()?;
+    Some((mime_type.to_string(), bytes))
+}
+
+pub fn delete_persona_assets(assets_dir: &Path, persona_id: Uuid) -> Result<()> {
+    let dir = assets_dir.join(persona_id.to_string());
+    match std::fs::remove_dir_all(&dir) {
+        Ok(()) => Ok(()),
+        Err(e) if e.kind() == ErrorKind::NotFound => Ok(()),
+        Err(e) => Err(e),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -61,5 +84,33 @@ mod tests {
         .expect("save asset");
 
         assert!(saved_path.exists());
+    }
+
+    #[test]
+    fn parse_data_uri_decodes_base64_bytes() {
+        let (mime_type, bytes) =
+            parse_data_uri("data:image/png;base64,aGVsbG8gd29ybGQ=").expect("parse data URI");
+
+        assert_eq!(mime_type, "image/png");
+        assert_eq!(bytes, b"hello world");
+    }
+
+    #[test]
+    fn delete_persona_assets_removes_directory() {
+        let temp_dir = TempDir::new().expect("create temp dir");
+        let persona_id = Uuid::now_v7();
+
+        save_persona_asset(temp_dir.path(), persona_id, AssetKind::Avatar, "image/png", b"bytes")
+            .unwrap();
+        assert!(temp_dir.path().join(persona_id.to_string()).exists());
+
+        delete_persona_assets(temp_dir.path(), persona_id).unwrap();
+        assert!(!temp_dir.path().join(persona_id.to_string()).exists());
+    }
+
+    #[test]
+    fn delete_persona_assets_ok_when_not_found() {
+        let temp_dir = TempDir::new().expect("create temp dir");
+        delete_persona_assets(temp_dir.path(), Uuid::now_v7()).unwrap();
     }
 }

--- a/crates/animus-server/src/assets.rs
+++ b/crates/animus-server/src/assets.rs
@@ -1,0 +1,65 @@
+use std::{
+    fs::{create_dir_all, write},
+    io::{Error, ErrorKind, Result},
+    path::{Path, PathBuf},
+};
+
+use uuid::Uuid;
+
+pub enum AssetKind {
+    Avatar,
+    Background,
+}
+
+pub fn save_persona_asset(
+    assets_dir: &Path,
+    persona_id: Uuid,
+    asset_type: AssetKind,
+    mime_type: &str,
+    raw_bytes: &[u8],
+) -> Result<PathBuf> {
+    let file_extension = match mime_type {
+        "image/png" => "png",
+        "image/jpeg" => "jpg",
+        "image/webp" => "webp",
+        _ => return Err(Error::new(ErrorKind::InvalidInput, "unsupported mime type")),
+    };
+
+    let dir = assets_dir.join(persona_id.to_string());
+
+    create_dir_all(&dir)?;
+
+    let filename_stem = match asset_type {
+        AssetKind::Avatar => "avatar",
+        AssetKind::Background => "background",
+    };
+
+    let filename = format!("{filename_stem}.{file_extension}");
+    let full_path = dir.join(filename);
+    write(&full_path, raw_bytes)?;
+    Ok(full_path)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use tempfile::TempDir;
+
+    #[test]
+    fn save_asset_writes_file_to_disk() {
+        let temp_dir = TempDir::new().expect("create temp dir");
+        let persona_id = Uuid::now_v7();
+
+        let saved_path = save_persona_asset(
+            temp_dir.path(),
+            persona_id,
+            AssetKind::Avatar,
+            "image/png",
+            b"image bytes",
+        )
+        .expect("save asset");
+
+        assert!(saved_path.exists());
+    }
+}

--- a/crates/animus-server/src/main.rs
+++ b/crates/animus-server/src/main.rs
@@ -52,6 +52,8 @@ async fn main() -> anyhow::Result<()> {
 
     let assets_dir = home.join(".animus/assets").to_string_lossy().into_owned();
     let backups_dir = home.join(".animus/backups").to_string_lossy().into_owned();
+    std::fs::create_dir_all(&assets_dir).context("failed to create assets directory")?;
+    std::fs::create_dir_all(&backups_dir).context("failed to create backups directory")?;
 
     let settings_repo = SettingsRepo::new(pool.clone());
     settings_repo

--- a/crates/animus-server/src/main.rs
+++ b/crates/animus-server/src/main.rs
@@ -1,3 +1,4 @@
+mod assets;
 mod error;
 mod routes;
 mod state;

--- a/crates/animus-server/src/routes/personas.rs
+++ b/crates/animus-server/src/routes/personas.rs
@@ -1,3 +1,4 @@
+use crate::assets::{delete_persona_assets, parse_data_uri, save_persona_asset, AssetKind};
 use animus_core::{
     persona::{
         DEFAULT_INSTRUCTION_TEMPLATE, DEFAULT_REPEAT_PENALTY, DEFAULT_RESPONSE_LENGTH_LIMIT,
@@ -7,9 +8,10 @@ use animus_core::{
 };
 use animus_db::persona_repo::RepoError;
 use axum::{
+    body::Body,
     extract::{Path, Query, State},
     http::StatusCode,
-    response::IntoResponse,
+    response::{IntoResponse, Response},
     routing::{get, post},
     Json, Router,
 };
@@ -26,6 +28,59 @@ pub fn router() -> Router<AppState> {
             "/api/personas/:id",
             get(get_persona).delete(remove_persona).patch(patch_persona),
         )
+        .route("/api/personas/:id/avatar", get(serve_persona_avatar))
+        .route("/api/personas/:id/background", get(serve_persona_background))
+}
+
+fn save_if_data_uri(
+    assets_dir: &std::path::Path,
+    persona_id: uuid::Uuid,
+    kind: AssetKind,
+    url: &str,
+) -> Result<Option<String>, ApiError> {
+    let Some((mime, bytes)) = parse_data_uri(url) else {
+        return Ok(None);
+    };
+    let stem = match kind {
+        AssetKind::Avatar => "avatar",
+        AssetKind::Background => "background",
+    };
+    save_persona_asset(assets_dir, persona_id, kind, &mime, &bytes).map_err(|_| ApiError::Internal)?;
+    Ok(Some(format!("/api/personas/{persona_id}/{stem}")))
+}
+
+async fn serve_asset_file(
+    assets_dir: &str,
+    persona_id: uuid::Uuid,
+    stem: &str,
+) -> Result<Response<Body>, ApiError> {
+    let base = std::path::Path::new(assets_dir).join(persona_id.to_string());
+    for (ext, mime) in [("png", "image/png"), ("jpg", "image/jpeg"), ("webp", "image/webp")] {
+        let path = base.join(format!("{stem}.{ext}"));
+        if path.exists() {
+            let bytes = tokio::fs::read(&path).await.map_err(|_| ApiError::Internal)?;
+            return Response::builder()
+                .status(StatusCode::OK)
+                .header("content-type", mime)
+                .body(Body::from(bytes))
+                .map_err(|_| ApiError::Internal);
+        }
+    }
+    Err(ApiError::NotFound)
+}
+
+async fn serve_persona_avatar(
+    State(state): State<AppState>,
+    Path(id): Path<uuid::Uuid>,
+) -> Result<impl IntoResponse, ApiError> {
+    serve_asset_file(&state.assets_dir, id, "avatar").await
+}
+
+async fn serve_persona_background(
+    State(state): State<AppState>,
+    Path(id): Path<uuid::Uuid>,
+) -> Result<impl IntoResponse, ApiError> {
+    serve_asset_file(&state.assets_dir, id, "background").await
 }
 
 // --- Import ---
@@ -171,7 +226,7 @@ async fn create_persona(
         return Err(ApiError::UnprocessableEntity("name is required".to_owned()));
     }
 
-    let persona = Persona {
+    let mut persona = Persona {
         id: Uuid::now_v7(),
         name: req.name,
         description: req.description,
@@ -194,6 +249,20 @@ async fn create_persona(
         repeat_penalty: req.repeat_penalty,
         instruction_template: req.instruction_template,
     };
+
+    let assets_dir = std::path::Path::new(&state.assets_dir);
+    if let Some(url) = persona.avatar_url.clone() {
+        if let Some(new_url) = save_if_data_uri(assets_dir, persona.id, AssetKind::Avatar, &url)? {
+            persona.avatar_url = Some(new_url);
+        }
+    }
+    if let Some(url) = persona.background_url.clone() {
+        if let Some(new_url) =
+            save_if_data_uri(assets_dir, persona.id, AssetKind::Background, &url)?
+        {
+            persona.background_url = Some(new_url);
+        }
+    }
 
     state.personas.insert(&persona).await.map_err(|e| match e {
         RepoError::Duplicate => {
@@ -252,6 +321,21 @@ async fn patch_persona(
     persona.model = req.model;
     persona.avatar_url = req.avatar_url;
     persona.background_url = req.background_url;
+
+    let assets_dir = std::path::Path::new(&state.assets_dir);
+    if let Some(url) = persona.avatar_url.clone() {
+        if let Some(new_url) = save_if_data_uri(assets_dir, persona.id, AssetKind::Avatar, &url)? {
+            persona.avatar_url = Some(new_url);
+        }
+    }
+    if let Some(url) = persona.background_url.clone() {
+        if let Some(new_url) =
+            save_if_data_uri(assets_dir, persona.id, AssetKind::Background, &url)?
+        {
+            persona.background_url = Some(new_url);
+        }
+    }
+
     persona.model_instructions = req.model_instructions;
     persona.appearance = req.appearance;
     persona.speech_style = req.speech_style;
@@ -327,6 +411,11 @@ async fn remove_persona(
         .map_err(|_| ApiError::Internal)?;
 
     if found {
+        if let Err(e) =
+            delete_persona_assets(std::path::Path::new(&state.assets_dir), id)
+        {
+            tracing::warn!(persona_id = %id, error = %e, "failed to delete persona assets");
+        }
         Ok(StatusCode::NO_CONTENT)
     } else {
         Err(ApiError::NotFound)
@@ -401,6 +490,10 @@ mod tests {
     static MIGRATOR: sqlx::migrate::Migrator = sqlx::migrate!("../animus-db/migrations");
 
     fn make_app(pool: SqlitePool) -> Router {
+        make_app_with_dirs(pool, "/tmp/assets")
+    }
+
+    fn make_app_with_dirs(pool: SqlitePool, assets_dir: &str) -> Router {
         let state = AppState {
             personas: PersonaRepo::new(pool.clone()),
             conversations: ConversationRepo::new(pool.clone()),
@@ -410,7 +503,7 @@ mod tests {
             ollama: OllamaClient::new("http://localhost:11434"),
             model_name: "gemma4".to_owned(),
             ollama_url: "http://localhost:11434".to_owned(),
-            assets_dir: "/tmp/assets".to_owned(),
+            assets_dir: assets_dir.to_owned(),
             backups_dir: "/tmp/backups".to_owned(),
         };
         router().with_state(state)
@@ -1034,6 +1127,95 @@ mod tests {
             .unwrap();
         assert_eq!(res.status(), StatusCode::CREATED);
         let body = body_json(res).await;
+        // invalid base64 → parse fails → original URL kept
         assert_eq!(body["avatar_url"], "data:image/png;base64,abc123");
+    }
+
+    // 1×1 transparent PNG
+    const TINY_PNG_B64: &str =
+        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==";
+
+    #[sqlx::test(migrator = "MIGRATOR")]
+    async fn create_valid_data_uri_stores_api_url(pool: SqlitePool) {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let app = make_app_with_dirs(pool, tmp.path().to_str().unwrap());
+        let body = serde_json::json!({
+            "name": "WithRealAvatar",
+            "avatar_url": format!("data:image/png;base64,{TINY_PNG_B64}"),
+        })
+        .to_string();
+        let res = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/personas")
+                    .header("content-type", "application/json")
+                    .body(axum::body::Body::from(body))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::CREATED);
+        let body = body_json(res).await;
+        let url = body["avatar_url"].as_str().unwrap();
+        assert!(url.starts_with("/api/personas/"));
+        assert!(url.ends_with("/avatar"));
+    }
+
+    #[sqlx::test(migrator = "MIGRATOR")]
+    async fn serve_avatar_returns_image_bytes(pool: SqlitePool) {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let assets_dir = tmp.path().to_str().unwrap();
+        let app = make_app_with_dirs(pool, assets_dir);
+
+        // Create persona with valid avatar
+        let create_body = serde_json::json!({
+            "name": "ServeTest",
+            "avatar_url": format!("data:image/png;base64,{TINY_PNG_B64}"),
+        })
+        .to_string();
+        let create_res = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/personas")
+                    .header("content-type", "application/json")
+                    .body(axum::body::Body::from(create_body))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(create_res.status(), StatusCode::CREATED);
+        let created = body_json(create_res).await;
+        let avatar_url = created["avatar_url"].as_str().unwrap().to_owned();
+
+        // Serve it back
+        let serve_res = app
+            .oneshot(
+                Request::builder()
+                    .uri(&avatar_url)
+                    .body(axum::body::Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(serve_res.status(), StatusCode::OK);
+        assert_eq!(serve_res.headers()["content-type"], "image/png");
+    }
+
+    #[sqlx::test(migrator = "MIGRATOR")]
+    async fn serve_avatar_returns_404_when_no_file(pool: SqlitePool) {
+        let app = make_app(pool);
+        let res = app
+            .oneshot(
+                Request::builder()
+                    .uri(format!("/api/personas/{}/avatar", uuid::Uuid::now_v7()))
+                    .body(axum::body::Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::NOT_FOUND);
     }
 }


### PR DESCRIPTION
## Summary
- Persist avatar and background images locally instead of storing URLs
- Parse data URIs and save to disk during persona creation/update
- Serve assets via new `/api/personas/:id/{avatar,background}` endpoints
- Clean up files when personas are deleted

## Test plan
- [x] Data URI parsing converts base64 to bytes correctly
- [x] Files are created in assets directory with UUID-based structure  
- [x] Avatar/background endpoints return correct MIME types
- [x] 404 returned when asset doesn't exist
- [x] Invalid data URIs keep original URL unchanged
- [x] Asset cleanup succeeds (or gracefully handles missing files)

🤖 Generated with Claude Code